### PR TITLE
Removed unnecessary list from nevergrad loop

### DIFF
--- a/src/constellaration/optimization/augmented_lagrangian_runner.py
+++ b/src/constellaration/optimization/augmented_lagrangian_runner.py
@@ -243,14 +243,13 @@ def run(
                     if settings.optimizer_settings.oracle_settings.batch_mode
                     else futures.FIRST_COMPLETED
                 )
-                new_completed, _ = futures.wait(
+                completed, _ = futures.wait(
                     [fut for fut, _ in running_evaluations],
                     return_when=return_when,
                 )
 
-                completed: list[tuple[futures.Future, param.Parameter]] = []
                 for future, candidate in running_evaluations:
-                    if future in new_completed:
+                    if future in completed:
                         n_function_evals += 1
 
                         (objective, constraints), _ = future.result()
@@ -261,13 +260,12 @@ def run(
                                 objective, constraints, state
                             ).item(),
                         )
-                        completed.append((future, candidate))
 
                 # Remove completed from the running list
                 running_evaluations = [
                     (fut, cand)
                     for fut, cand in running_evaluations
-                    if fut not in new_completed
+                    if fut not in completed
                 ]
 
             recommendation = oracle.provide_recommendation()


### PR DESCRIPTION
### TL;DR

Simplified the future handling logic in the augmented Lagrangian optimization code.

### What changed?

- Renamed `new_completed` to `completed` for clarity
- Removed the unnecessary creation of a separate `completed` list
- Updated references to use the renamed variable consistently
- Applied these changes in both the toy example and the main runner implementation

### How to test?

Run the augmented Lagrangian optimization examples to verify that the optimization process still works correctly:
```
python optimization_examples/augmented_lagrangian_toy_example.py
```

Also, run any tests that use the augmented Lagrangian runner to ensure functionality is preserved.

### Why make this change?

This change improves code readability and removes redundant operations. The previous implementation created an unnecessary list of completed futures, when the result from `futures.wait()` already provides this information. The simplified code is more direct and easier to understand while maintaining the same functionality.