### PR TITLE
Fix: Added VMEC equilibrium calculation before Boozer plots

### DIFF
--- a/notebooks/boundary_explorer.ipynb
+++ b/notebooks/boundary_explorer.ipynb
@@ -30,6 +30,11 @@
                 "    file_exporter,\n",
                 "    visualization,\n",
                 "    visualization_utils,\n",
+                ")\n",
+                "from constellaration.mhd import (\n",
+                "    vmec_utils,\n",
+                "    vmec_settings as vmec_settings_module,\n",
+                "    ideal_mhd_parameters as ideal_mhd_parameters_module,\n",
                 ")"
             ]
         },
@@ -144,7 +149,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 6,
+            "execution_count": null,
             "id": "7aa58984",
             "metadata": {},
             "outputs": [
@@ -216,6 +221,36 @@
             "metadata": {},
             "source": [
                 "## Boozer plots"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "e7e0e1ed",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Compute the equilibrium\n",
+                "vmec_preset_settings = vmec_settings_module.VmecPresetSettings(\n",
+                "    fidelity=\"low_fidelity\",\n",
+                ")\n",
+                "vmec_settings = vmec_settings_module.create_vmec_settings_from_preset(\n",
+                "    compact_boundary,\n",
+                "    settings=vmec_preset_settings,\n",
+                ")\n",
+                "ideal_mhd_parameters = ideal_mhd_parameters_module.boundary_to_ideal_mhd_parameters(\n",
+                "    compact_boundary\n",
+                ")\n",
+                "compact_boundary_equilibrium = vmec_utils.run_vmec(\n",
+                "    boundary=compact_boundary,\n",
+                "    mhd_parameters=ideal_mhd_parameters,\n",
+                "    vmec_settings=vmec_settings,\n",
+                ")\n",
+                "elongated_boundary_equilibrium = vmec_utils.run_vmec(\n",
+                "    boundary=elongated_boundary,\n",
+                "    mhd_parameters=ideal_mhd_parameters,\n",
+                "    vmec_settings=vmec_settings,\n",
+                ")"
             ]
         },
         {


### PR DESCRIPTION
### Summary

This PR adds VMEC equilibrium calculations before the Boozer plot in the Jupyter notebook `notebooks/boundary_explorer.ipynb`.

### Context

I noticed this could not run while exploring the notebook as a student. I hope this small fix is helpful!

### Changes

- Added VMEC imports at the top for equilibrium calculation
- Added VMEC equilibrium calculation before Boozer plots

Thank you for the work on this project!