### PR TITLE
Hotfix breaking incompatibility from pybind11 (imported via booz-xform)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "booz-xform==0.0.8",
+  "pybind11<3.0.0", # Breaking change in 3.0.0 triggers an incompatibility with booz-xform on MAC https://github.com/hiddenSymmetries/booz_xform/pull/21
+  "booz-xform@git+https://github.com/jurasic-pf/booz_xform.git#egg=ea73108c9d035cafb35d7282143ff1edb384d191",
   "datasets==3.5.1",
   "desc-opt",
   "ipython",
@@ -46,7 +47,9 @@ dependencies = [
   "scikit-activeml==0.5.2",
   "scikit-build-core==0.10",
   "scikit-learn==1.5.2",
-  "simsopt==1.8.1",
+  # Use newer simsopt for Python 3.13 compatibility
+  "simsopt==1.8.1; python_version < '3.13'",
+  "simsopt==1.9.0; python_version >= '3.13'",
   "seaborn==0.13.2",
   "vmecpp==0.4.2",
 ]


### PR DESCRIPTION
It seems the major version update in pybind11 was a breaking change for booz_xform.
Issue raised with booz-xform https://github.com/hiddenSymmetries/booz_xform/issues/20 but until this is merged, we need to constraint the versions ourselves.