### PR TITLE
Update file_exporter.py

### DIFF
--- a/src/constellaration/mhd/vmec_utils.py
+++ b/src/constellaration/mhd/vmec_utils.py
@@ -329,7 +329,12 @@ def as_simsopt_vmec(equilibrium: VmecppWOut) -> mhd.Vmec:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = pathlib.Path(tmpdir)
         wout_path = tmpdir / "wout_temp.nc"
-        equilibrium.save(wout_path)
+        extras = None
+        if equilibrium.model_extra is not None:
+            extras = set(equilibrium.model_extra.keys())
+        VmecppWOut.model_validate(equilibrium.model_dump(exclude=extras)).save(
+            wout_path,
+        )
         return mhd.Vmec(wout_path.as_posix())
 
 

--- a/src/constellaration/utils/file_exporter.py
+++ b/src/constellaration/utils/file_exporter.py
@@ -8,7 +8,12 @@ def to_vmec2000_wout_file(
     equilibrium: vmec_utils.VmecppWOut, output_file: pathlib.Path
 ) -> None:
     """Writes a VMEC equilibrium to a VMEC2000 wout file."""
-    equilibrium.save(output_file)
+    extras = None
+    if equilibrium.model_extra is not None:
+        extras = set(equilibrium.model_extra.keys())
+    vmec_utils.VmecppWOut.model_validate(equilibrium.model_dump(exclude=extras)).save(
+        output_file,
+    )
 
 
 def to_vmec2000_input_file(


### PR DESCRIPTION
Bugfix for saving wout loaded from database, specifically handling the edge case for empty fields, unsupported by `vmecpp` but available in the old format (e.g. curlabel). Once we support curlabel in vmecpp as well, this won't be necessary any longer, but this is definitely a forward compatible change.