### PR TITLE
Add function to generate data agumentations of a boundary

### DIFF
--- a/src/constellaration/utils/types.py
+++ b/src/constellaration/utils/types.py
@@ -10,3 +10,9 @@ Use this as a return type ONLY if all your callers need to be able to handle JAX
 Otherwise, use `NpOrJaxArrayT` instead for both the input arguments and the return type,
 so callers that are not aware of JAX can still use numpy functions.
 """
+
+ScalarFloat = float | jt.Float[NpOrJaxArray, " "]
+"""Either a normal Python float or a scalar NpOrJaxArray.
+
+Useful for functions that used to take Python floats and are now being jaxified.
+"""


### PR DESCRIPTION
The augmentations generate new boundaries that match the 3d shape of the original boundary. Note that some metrics (e.g. edge rotational transform) may flip the sign according to the augmentation due to convention.