### PR TITLE
Update dependency versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,11 @@ dependencies = [
   "matplotlib==3.9.2",
   "nbformat",
   "nevergrad",
-  "numpy==2.1.3",
+  "numpy>=2.1.3",
   "orjson==3.10.16",
   "plotly<7.0.0",
   "pydantic",
-  # need an unreleased version to fix `cma` compatibility with numpy 2.0
-  "pymoo==0.6.1.5.dev0",
+  "pymoo==0.6.1.5",
   "pandas==2.2.3",
   "qicna==0.3.4",
   "scipy",
@@ -52,7 +51,7 @@ dependencies = [
   "simsopt==1.8.1; python_version < '3.13'",
   "simsopt==1.9.0; python_version >= '3.13'",
   "seaborn==0.13.2",
-  "vmecpp==0.4.7",
+  "vmecpp==0.4.11",
 ]
 
 [tool.hatch.metadata]

--- a/src/constellaration/generative_model/bootstrap_dataset.py
+++ b/src/constellaration/generative_model/bootstrap_dataset.py
@@ -282,7 +282,7 @@ def _n_components_that_minimizes_bic(
     """Finds the number of components that minimizes BIC for a GMM."""
     n_components_to_try = np.arange(2, 50)
     gmm_candidates = [
-        mixture.GaussianMixture(n, random_state=seed) for n in n_components_to_try
+        mixture.GaussianMixture(int(n), random_state=seed) for n in n_components_to_try
     ]
     gmm_candidates_bics = []
     for i, model in enumerate(gmm_candidates):


### PR DESCRIPTION
Bugfixes in vmecpp
bootstrap change due to type-checking

(CI change because mac 13 runners have been deprecated by GitHub.)