### PR TITLE
PyPi release auto versioning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for tags
 
       - uses: actions/setup-python@v5
         with:
@@ -29,7 +31,7 @@ jobs:
       - name: Build release distributions
         run: |
           # NOTE: put your own distribution build steps here.
-          python -m pip install hatchling
+          python -m pip install hatchling hatch-vcs
           python -m hatchling build
 
       - name: Upload distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -63,7 +63,10 @@ Issues = "https://github.com/proximafusion/constellaration/issues"
 Source = "https://github.com/proximafusion/constellaration"
 
 [tool.hatch.version]
-path = "src/constellaration/__about__.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/constellaration/__about__.py"
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/src/constellaration/__about__.py
+++ b/src/constellaration/__about__.py
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2025-present Proxima Fusion GmbH <info@proximafusion.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.2.4"
+
+# This file is automatically updated by hatch-vcs during build based on git tags
+__version__ = "0.2.5"


### PR DESCRIPTION
### TL;DR

Implement version control system (VCS) based versioning using hatch-vcs

### What changed?

- Added `hatch-vcs` to build dependencies in `pyproject.toml`
- Configured Hatch to use VCS for versioning instead of hardcoded version
- Updated GitHub workflow to install `hatch-vcs` and fetch full git history
- Added a comment in `__about__.py` explaining that the version is automatically updated


### Why make this change?

This change automates version management by deriving the package version from git tags instead of requiring manual updates to `__about__.py`. This reduces the risk of version inconsistencies and simplifies the release process by centralizing version information in git tags.