### PR TITLE
Add spectral condensation for SurfaceRZFourier

### DIFF
--- a/src/constellaration/geometry/spectral_condensation.py
+++ b/src/constellaration/geometry/spectral_condensation.py
@@ -1,0 +1,302 @@
+"""Spectral condensation of SurfaceRZFourier surfaces.
+
+Derives a new set of Fourier coefficients that represent the same surface geometry
+but with reduced spectral width, by minimizing the spectral width subject to a
+constraint that the surface points do not move beyond a given tolerance.
+"""
+
+import dataclasses
+import logging
+from collections.abc import Callable
+
+import jaxtyping as jt
+import numpy as np
+from scipy import optimize
+
+from constellaration.geometry import surface_rz_fourier, surface_utils
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class SpectralCondensationSettings:
+    """Settings for spectral condensation of a SurfaceRZFourier surface."""
+
+    p: int = 4
+    """Poloidal mode exponent in the spectral width denominator."""
+
+    q: int = 1
+    """Poloidal mode exponent in the spectral width numerator."""
+
+    normalize: bool = True
+    """Whether to normalize the spectral width."""
+
+    maximum_normal_displacement: float = float(np.finfo(float).eps)
+    """Maximum allowed normal displacement of the condensed surface from the
+    original."""
+
+    energy_scale: float = 3.5
+    """Energy-based spectrum scaling factor for preconditioning."""
+
+    bounds: float = 1.0
+    """Symmetric bounds on the normalized optimization variables."""
+
+    n_restarts: int = 0
+    """Number of optimization restarts from the previous best solution."""
+
+
+def spectrally_condense_surface(
+    surface: surface_rz_fourier.SurfaceRZFourier,
+    settings: SpectralCondensationSettings | None = None,
+) -> surface_rz_fourier.SurfaceRZFourier:
+    r"""Spectrally condense a SurfaceRZFourier surface.
+
+    Minimizes the spectral width of the Fourier representation while constraining
+    the discretized surface points to remain within a given normal displacement
+    tolerance of the original surface.
+
+    The spectral width is defined as:
+
+    .. math::
+        W = \sum_{m,n} m^{p+q} (r_{m,n}^2 + z_{m,n}^2)
+
+    optionally normalized by :math:`\sum_{m,n} m^p (r_{m,n}^2 + z_{m,n}^2)`.
+
+    Args:
+        surface: The surface to condense.
+        settings: Optimization settings.  Uses defaults when ``None``.
+
+    Returns:
+        A new SurfaceRZFourier with reduced spectral width.
+
+    Raises:
+        NotImplementedError: If the surface is not stellarator symmetric.
+    """
+    if settings is None:
+        settings = SpectralCondensationSettings()
+
+    if not surface.is_stellarator_symmetric:
+        raise NotImplementedError(
+            "Non stellarator symmetric surfaces are not supported yet."
+        )
+
+    # Determine free variables --------------------------------------------------
+    ntor = surface.max_toroidal_mode
+
+    free_r = np.ones(surface.r_cos.shape, dtype=bool)
+    free_r[0, :ntor] = False  # r_cos(m=0, n<0) fixed at 0
+    free_r[0, ntor] = False  # r_cos(0,0) - major radius
+
+    free_z = np.ones(surface.z_sin.shape, dtype=bool)
+    free_z[0, : ntor + 1] = False  # z_sin(m=0, n<=0) fixed at 0
+
+    n_free_r = int(free_r.sum())
+
+    # Energy spectrum scaling for preconditioning -------------------------------
+    # Uses the same exp-based formula as the reference implementation to ensure
+    # the energy_scale default (3.5) works well.
+    energy = surface.poloidal_modes**2 + surface.toroidal_modes**2
+    scale = np.exp(-np.sqrt(energy.astype(np.float64)) / settings.energy_scale)
+
+    r_cos_0 = np.array(surface.r_cos, dtype=np.float64)
+    z_sin_0 = np.array(surface.z_sin, dtype=np.float64)
+
+    # Pre-compute mode weights for the analytical gradient
+    m = surface.poloidal_modes.astype(np.float64)
+    w_num = m ** (settings.p + settings.q)  # numerator weight
+    w_den = m**settings.p  # denominator weight
+
+    def _x_to_coeffs(
+        x: jt.Float[np.ndarray, " n"],
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Optimization vector -> (r_cos, z_sin) arrays."""
+        r_cos = r_cos_0.copy()
+        z_sin = z_sin_0.copy()
+        r_cos[free_r] += x[:n_free_r] * scale[free_r]
+        z_sin[free_z] += x[n_free_r:] * scale[free_z]
+        return r_cos, z_sin
+
+    def _x_to_surface(
+        x: jt.Float[np.ndarray, " n"],
+    ) -> surface_rz_fourier.SurfaceRZFourier:
+        r_cos, z_sin = _x_to_coeffs(x)
+        return surface.model_copy(update=dict(r_cos=r_cos, z_sin=z_sin))
+
+    def _objective_and_grad(
+        x: jt.Float[np.ndarray, " n"],
+    ) -> tuple[float, np.ndarray]:
+        """Spectral width value and gradient w.r.t. x."""
+        r_cos, z_sin = _x_to_coeffs(x)
+        coeff_sq = r_cos**2 + z_sin**2
+
+        numerator = float(np.sum(w_num * coeff_sq))
+        denominator = float(np.sum(w_den * coeff_sq))
+
+        if settings.normalize and denominator != 0.0:
+            value = numerator / denominator
+            # dW/dc = 2*c*(w_num*D - w_den*N) / D^2 = 2*c*(w_num - w_den*W) / D
+            common = 2.0 * (w_num - w_den * value) / denominator
+        else:
+            value = numerator
+            common = 2.0 * w_num
+
+        grad_r_full = common * r_cos
+        grad_z_full = common * z_sin
+        # Chain rule: dx -> coefficients includes the scale factor
+        grad = np.concatenate(
+            [grad_r_full[free_r] * scale[free_r], grad_z_full[free_z] * scale[free_z]]
+        )
+        return value, grad
+
+    # Hessian-based preconditioning ---------------------------------------------
+    x0 = np.zeros(n_free_r + int(free_z.sum()))
+    hessian = _approx_hessian(lambda x: _objective_and_grad(x)[0], x0)
+    eigvals, _ = np.linalg.eigh(hessian)
+    with np.errstate(divide="ignore"):
+        preconditioner = np.where(
+            np.abs(eigvals) > 1e-30, np.sqrt(1.0 / np.abs(eigvals)), 1.0
+        )
+    logger.debug("Preconditioner: %s", preconditioner)
+
+    def preconditioned_value_and_grad(
+        y: jt.Float[np.ndarray, " n"],
+    ) -> tuple[float, np.ndarray]:
+        """Preconditioned objective returning (value, gradient)."""
+        val, grad_x = _objective_and_grad(preconditioner * y)
+        return val, grad_x * preconditioner
+
+    # Constraint: normal displacement -------------------------------------------
+    n_pol, n_tor = (
+        surface_utils.n_poloidal_toroidal_points_to_satisfy_nyquist_criterion(
+            surface.n_poloidal_modes, surface.max_toroidal_mode
+        )
+    )
+    if surface.max_toroidal_mode == 0:
+        n_tor = 1
+
+    _normal_distance_fn = _create_normal_distance_constraint(
+        target_surface=surface,
+        n_poloidal_points=n_pol,
+        n_toroidal_points=n_tor,
+    )
+
+    def preconditioned_constraint(y: jt.Float[np.ndarray, " n"]) -> np.ndarray:
+        return _normal_distance_fn(_x_to_surface(preconditioner * y))
+
+    constraint = optimize.NonlinearConstraint(
+        fun=preconditioned_constraint,
+        lb=-settings.maximum_normal_displacement,
+        ub=settings.maximum_normal_displacement,
+    )
+
+    # Optimization loop ---------------------------------------------------------
+    preconditioned_x = x0.copy()
+    result: optimize.OptimizeResult | None = None
+    for restart in range(settings.n_restarts + 1):
+        logger.info("Spectral condensation, restart %d.", restart)
+        restart_x0 = preconditioned_x if restart > 0 else np.zeros_like(x0)
+        result = optimize.minimize(
+            fun=preconditioned_value_and_grad,
+            x0=restart_x0,
+            method="trust-constr",
+            jac=True,
+            constraints=[constraint],
+            options={"maxiter": 1000},
+            bounds=optimize.Bounds(
+                lb=-settings.bounds * np.ones_like(x0),
+                ub=settings.bounds * np.ones_like(x0),
+            ),
+        )
+        logger.debug("Optimizer result: %s", result)
+        if result.status not in (0, 1):
+            logger.warning("Optimization did not converge: %s", result.message)
+        preconditioned_x = result.x.copy()
+
+    assert result is not None
+
+    violation = np.max(np.abs(preconditioned_constraint(result.x)))
+    logger.debug("Constraint violation inf-norm: %s", violation)
+
+    return _x_to_surface(preconditioner * result.x)
+
+
+def _create_normal_distance_constraint(
+    target_surface: surface_rz_fourier.SurfaceRZFourier,
+    n_poloidal_points: int,
+    n_toroidal_points: int,
+) -> Callable[[surface_rz_fourier.SurfaceRZFourier], np.ndarray]:
+    """Build a constraint function that measures normal distance to *target_surface*.
+
+    The reference surface data (xyz, unit normals) is pre-computed once so that
+    only the comparison surface needs to be evaluated at each optimization step.
+    """
+    phi_upper_bound = (
+        2.0
+        * np.pi
+        / target_surface.n_field_periods
+        / (1.0 + int(target_surface.is_stellarator_symmetric))
+    )
+    theta_phi = surface_utils.make_theta_phi_grid(
+        n_theta=n_poloidal_points,
+        n_phi=n_toroidal_points,
+        phi_upper_bound=phi_upper_bound,
+    )
+
+    ref_xyz = np.asarray(
+        surface_rz_fourier.evaluate_points_xyz(target_surface, theta_phi)
+    )
+    ref_normal = np.asarray(
+        surface_rz_fourier.evaluate_unit_normal(target_surface, theta_phi)
+    )
+
+    def constraint_fn(
+        comparison_surface: surface_rz_fourier.SurfaceRZFourier,
+    ) -> np.ndarray:
+        new_xyz = np.asarray(
+            surface_rz_fourier.evaluate_points_xyz(comparison_surface, theta_phi)
+        )
+        n_points = n_poloidal_points * n_toroidal_points
+        distances = np.empty(n_points)
+        idx = 0
+        for j in range(n_toroidal_points):
+            ref_at_phi = ref_xyz[:, j, :]
+            normals_at_phi = ref_normal[:, j, :]
+            new_at_phi = new_xyz[:, j, :]
+            diff = new_at_phi[:, np.newaxis, :] - ref_at_phi[np.newaxis, :, :]
+            dist_sq = np.sum(diff * diff, axis=-1)
+            closest = np.argmin(dist_sq, axis=1)
+            delta = new_at_phi - ref_at_phi[closest]
+            normal_closest = normals_at_phi[closest]
+            distances[idx : idx + n_poloidal_points] = np.sum(
+                delta * normal_closest, axis=-1
+            )
+            idx += n_poloidal_points
+        return distances
+
+    return constraint_fn
+
+
+def _approx_hessian(
+    fun: Callable[[np.ndarray], float],
+    x0: np.ndarray,
+    eps: float = 1e-5,
+) -> np.ndarray:
+    """Approximate the Hessian of *fun* at *x0* via finite differences."""
+    n = len(x0)
+    hessian = np.zeros((n, n))
+    f0 = fun(x0)
+    fi = np.empty(n)
+    for i in range(n):
+        ei = np.zeros(n)
+        ei[i] = eps
+        fi[i] = fun(x0 + ei)
+    for i in range(n):
+        ei = np.zeros(n)
+        ei[i] = eps
+        for j in range(i, n):
+            ej = np.zeros(n)
+            ej[j] = eps
+            fij = fun(x0 + ei + ej)
+            hessian[i, j] = (fij - fi[i] - fi[j] + f0) / (eps * eps)
+            hessian[j, i] = hessian[i, j]
+    return hessian

--- a/src/constellaration/geometry/spectral_condensation.py
+++ b/src/constellaration/geometry/spectral_condensation.py
@@ -47,7 +47,7 @@ class SpectralCondensationSettings:
 
 def spectrally_condense_surface(
     surface: surface_rz_fourier.SurfaceRZFourier,
-    settings: SpectralCondensationSettings | None = None,
+    settings: SpectralCondensationSettings = SpectralCondensationSettings(),
 ) -> surface_rz_fourier.SurfaceRZFourier:
     r"""Spectrally condense a SurfaceRZFourier surface.
 
@@ -64,7 +64,7 @@ def spectrally_condense_surface(
 
     Args:
         surface: The surface to condense.
-        settings: Optimization settings.  Uses defaults when ``None``.
+        settings: Optimization settings.
 
     Returns:
         A new SurfaceRZFourier with reduced spectral width.
@@ -72,9 +72,6 @@ def spectrally_condense_surface(
     Raises:
         NotImplementedError: If the surface is not stellarator symmetric.
     """
-    if settings is None:
-        settings = SpectralCondensationSettings()
-
     if not surface.is_stellarator_symmetric:
         raise NotImplementedError(
             "Non stellarator symmetric surfaces are not supported yet."

--- a/tests/geometry/spectral_condensation_test.py
+++ b/tests/geometry/spectral_condensation_test.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pytest
+
+from constellaration.geometry import surface_rz_fourier
+from constellaration.geometry.spectral_condensation import (
+    SpectralCondensationSettings,
+    spectrally_condense_surface,
+)
+
+# Reference shapes from Hirshman 1985:
+# "Optimized Fourier representations for three-dimensional magnetic surfaces."
+# The Physics of fluids 28.5 (1985): 1387-1391.
+HIRSHMAN_1985: list[surface_rz_fourier.SurfaceRZFourier] = [
+    # Square
+    surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([3.0, 0.427, 0.0, 0.07322]).reshape(-1, 1),
+        z_sin=np.array([0.0, 0.427, 0.0, -0.07322]).reshape(-1, 1),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    ),
+    # Belt pinch
+    surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([3.0, 0.453, 0.0, 0.0]).reshape(-1, 1),
+        z_sin=np.array([0.0, 0.60, 0.0, 0.196]).reshape(-1, 1),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    ),
+    # D-Shape
+    surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([3.0, 0.991, 0.136]).reshape(-1, 1),
+        z_sin=np.array([0.0, 1.409, -0.118]).reshape(-1, 1),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    ),
+    # Heliac
+    surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array(
+            [
+                [0.0, 0.0, 0.0, 4.115, 0.475, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.323, -0.0621, 0.136, -0.0415],
+                [0.0, 0.0, 0.0, 0.0136, 0.0806, -0.0205, 0.0445],
+            ]
+        ),
+        z_sin=np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, -0.505, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.337, 0.0836, 0.133, -0.0409],
+                [0.0, 0.0, 0.0, 0.0155, 0.0619, -0.0382, -0.0237],
+            ]
+        ),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    ),
+]
+
+rng = np.random.default_rng(42)
+
+RANDOMLY_GENERATED_SURFACES: list[surface_rz_fourier.SurfaceRZFourier] = []
+for _ in range(3):
+    _nfp = int(rng.integers(1, 5))
+    _mpol = int(rng.integers(2, 8))
+    _ntor = 0
+    _scale = np.arange(0, _mpol + 1)[:, None] ** 3
+    _scale[0] = 1.0
+    _r_cos = rng.standard_normal((_mpol + 1, 2 * _ntor + 1)) / _scale
+    _r_cos[0, :_ntor] = 0.0
+    _r_cos[0, _ntor] = 10.0
+    _z_sin = rng.standard_normal((_mpol + 1, 2 * _ntor + 1)) / _scale
+    _z_sin[0, : _ntor + 1] = 0.0
+    RANDOMLY_GENERATED_SURFACES.append(
+        surface_rz_fourier.SurfaceRZFourier(
+            r_cos=_r_cos,
+            z_sin=_z_sin,
+            n_field_periods=_nfp,
+            is_stellarator_symmetric=True,
+        )
+    )
+
+SURFACES = HIRSHMAN_1985 + RANDOMLY_GENERATED_SURFACES
+
+
+@pytest.mark.parametrize("surface", SURFACES)
+def test_spectrally_condense_surface_lowers_spectral_width(
+    surface: surface_rz_fourier.SurfaceRZFourier,
+) -> None:
+    settings = SpectralCondensationSettings(
+        p=1,
+        q=1,
+        normalize=False,
+        maximum_normal_displacement=1e-3,
+    )
+    condensed = spectrally_condense_surface(surface, settings)
+
+    init_width = float(
+        surface_rz_fourier.spectral_width(
+            [surface.r_cos, surface.z_sin], p=1, q=1, normalize=False
+        )
+    )
+    final_width = float(
+        surface_rz_fourier.spectral_width(
+            [condensed.r_cos, condensed.z_sin], p=1, q=1, normalize=False
+        )
+    )
+    rtol = 1e-3
+    assert init_width > final_width * (1 + rtol)


### PR DESCRIPTION
## Summary
- Adds `spectrally_condense_surface()` that minimizes the spectral width of Fourier coefficients while constraining the surface geometry to stay within a given normal displacement tolerance
- Uses `scipy.optimize.minimize` with `trust-constr` method, analytical objective gradients, Hessian-based preconditioning, and energy spectrum scaling
- Reuses existing constellaration functions: `spectral_width`, `evaluate_points_xyz`, `evaluate_unit_normal`, `make_theta_phi_grid`, `n_poloidal_toroidal_points_to_satisfy_nyquist_criterion`

## Details

New file `src/constellaration/geometry/spectral_condensation.py`:

| Component | Description |
|---|---|
| `SpectralCondensationSettings` | Frozen dataclass with p, q, normalize, max displacement, energy scale, bounds, n_restarts |
| `spectrally_condense_surface()` | Main entry point — builds free-variable mask, applies preconditioning, runs constrained optimization |
| `_create_normal_distance_constraint()` | Factory that pre-computes reference surface data and returns a vectorized constraint function |
| `_approx_hessian()` | Numerical Hessian via finite differences for eigenvalue-based preconditioning |

**Algorithm**:
1. Identify free Fourier coefficients (excluding stellarator symmetry constraints and major radius)
2. Apply energy spectrum scaling as preconditioning
3. Compute Hessian eigenvalues for additional preconditioning
4. Minimize spectral width subject to normal displacement constraint
5. Support multiple restarts

## Test plan
- [x] 4 Hirshman 1985 reference shapes (square, belt pinch, D-shape, heliac) — all show >0.1% spectral width reduction
- [x] 3 randomly generated surfaces — all show >0.1% reduction
- [x] All 55 existing tests still pass
- [x] ruff, black, isort all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)