### PR TITLE
Add Medium and Loose tightness variants of MHD-stable QI problem

### DIFF
--- a/src/constellaration/problems.py
+++ b/src/constellaration/problems.py
@@ -402,6 +402,50 @@ class MHDStableQIStellarator(MultiObjectiveProblem, pydantic.BaseModel):
         return constraint_violations / np.abs(constraint_targets)
 
 
+class MHDStableQIStellaratorMedium(MHDStableQIStellarator):
+    """Medium-tightness variant of :class:`MHDStableQIStellarator`.
+
+    Constraint bounds (1% tolerance applied as in the parent class):
+        * Edge rotational transform / NFP >= 0.20
+        * log10(QI residuals) <= -3.5
+        * Edge magnetic mirror ratio <= 0.25
+        * Flux compression in regions of bad curvature <= 0.9
+        * Vacuum well >= -0.025
+    """
+
+    _edge_rotational_transform_over_n_field_periods_lower_bound: float = 0.20
+
+    _log10_qi_upper_bound: float = -3.5
+
+    _edge_magnetic_mirror_ratio_upper_bound: float = 0.25
+
+    _flux_compression_in_regions_of_bad_curvature_upper_bound: float = 0.9
+
+    _vacuum_well_lower_bound: float = -0.025
+
+
+class MHDStableQIStellaratorLoose(MHDStableQIStellarator):
+    """Loose-tightness variant of :class:`MHDStableQIStellarator`.
+
+    Constraint bounds (1% tolerance applied as in the parent class):
+        * Edge rotational transform / NFP >= 0.15
+        * log10(QI residuals) <= -3.0
+        * Edge magnetic mirror ratio <= 0.30
+        * Flux compression in regions of bad curvature <= 1.1
+        * Vacuum well >= -0.05
+    """
+
+    _edge_rotational_transform_over_n_field_periods_lower_bound: float = 0.15
+
+    _log10_qi_upper_bound: float = -3.0
+
+    _edge_magnetic_mirror_ratio_upper_bound: float = 0.30
+
+    _flux_compression_in_regions_of_bad_curvature_upper_bound: float = 1.1
+
+    _vacuum_well_lower_bound: float = -0.05
+
+
 def _hypervolume(
     X: jt.Float[np.ndarray, "n_points n_metrics"],
     reference_point: jt.Float[np.ndarray, " n_metrics"],

--- a/tests/problems_test.py
+++ b/tests/problems_test.py
@@ -103,6 +103,42 @@ def test_mhd_stable_problem_score_non_dominated_set_infeasible() -> None:
     assert problem._score(candidates) == 0.0
 
 
+def test_mhd_stable_medium_admits_relaxed_iota_and_negative_vacuum_well() -> None:
+    metrics = _get_test_metrics().model_copy(
+        update=dict(
+            edge_rotational_transform_over_n_field_periods=0.21,
+            vacuum_well=-0.02,
+        )
+    )
+    assert not problems.MHDStableQIStellarator().is_feasible(metrics)
+    assert problems.MHDStableQIStellaratorMedium().is_feasible(metrics)
+
+
+def test_mhd_stable_loose_admits_relaxed_qi_mirror_flux_and_vacuum_well() -> None:
+    metrics = _get_test_metrics().model_copy(
+        update=dict(
+            edge_rotational_transform_over_n_field_periods=0.16,
+            qi=10 ** (-3.05),
+            edge_magnetic_mirror_ratio=0.28,
+            flux_compression_in_regions_of_bad_curvature=1.05,
+            vacuum_well=-0.04,
+        )
+    )
+    assert not problems.MHDStableQIStellarator().is_feasible(metrics)
+    assert not problems.MHDStableQIStellaratorMedium().is_feasible(metrics)
+    assert problems.MHDStableQIStellaratorLoose().is_feasible(metrics)
+
+
+def test_mhd_stable_tight_unchanged_after_adding_medium_and_loose() -> None:
+    # Sanity check that the leaderboard-facing class still exposes the same defaults.
+    tight = problems.MHDStableQIStellarator()
+    assert tight._edge_rotational_transform_over_n_field_periods_lower_bound == 0.25
+    assert tight._log10_qi_upper_bound == -3.5
+    assert tight._edge_magnetic_mirror_ratio_upper_bound == 0.25
+    assert tight._flux_compression_in_regions_of_bad_curvature_upper_bound == 0.9
+    assert tight._vacuum_well_lower_bound == 0.0
+
+
 def _get_test_metrics() -> forward_model.ConstellarationMetrics:
     return forward_model.ConstellarationMetrics(
         aspect_ratio=4.0,


### PR DESCRIPTION
The Tight level is already represented by the existing
MHDStableQIStellarator. Adds two sibling subclasses with relaxed constraint bounds so submissions
can be evaluated at each tightness level without changing the
leaderboard-facing API of MHDStableQIStellarator.