### PR TITLE
Add scale_to_aspect_ratio for boundary normalization

### DIFF
--- a/src/constellaration/geometry/surface_rz_fourier.py
+++ b/src/constellaration/geometry/surface_rz_fourier.py
@@ -334,6 +334,97 @@ def compute_mean_cross_sectional_area(
     return mean_cross_sectional_area
 
 
+def compute_aspect_ratio(surface: SurfaceRZFourier) -> float:
+    """Aspect ratio (major / minor radius) of the surface, via simsopt."""
+    return float(to_simsopt(surface).aspect_ratio())
+
+
+def scale_to_aspect_ratio(
+    surface: SurfaceRZFourier,
+    target_aspect_ratio: float,
+    absolute_tolerance: float = 1e-3,
+    max_iterations: int = 50,
+) -> SurfaceRZFourier:
+    """Scale poloidal (m != 0) Fourier modes to match ``target_aspect_ratio``.
+
+    The major radius (the m=n=0 mode of ``r_cos``) is preserved; all m != 0 modes
+    are multiplied by a single factor found by bisection.
+
+    Args:
+        surface: The surface to rescale.
+        target_aspect_ratio: Desired aspect ratio. Must be > 0.
+        absolute_tolerance: Stop once ``|aspect_ratio - target| <= absolute_tolerance``.
+        max_iterations: Maximum bisection iterations.
+
+    Returns:
+        A new ``SurfaceRZFourier`` with the same major radius and rescaled
+        poloidal modes.
+
+    Raises:
+        ValueError: If ``target_aspect_ratio`` is not positive or the initial aspect
+            ratio is not finite.
+    """
+    if target_aspect_ratio <= 0:
+        raise ValueError(f"target_aspect_ratio must be > 0, got {target_aspect_ratio}")
+
+    initial_aspect_ratio = compute_aspect_ratio(surface)
+    if not np.isfinite(initial_aspect_ratio) or initial_aspect_ratio <= 0:
+        raise ValueError(
+            f"initial aspect ratio is not finite and positive: {initial_aspect_ratio}"
+        )
+
+    # The minor radius scales linearly with the m!=0 mode amplitude, so the
+    # analytic estimate is exact up to discretization noise.
+    center = initial_aspect_ratio / target_aspect_ratio
+
+    def aspect_at(scale: float) -> float:
+        return compute_aspect_ratio(_scale_poloidal_modes(surface, scale))
+
+    # Bracket around the analytic estimate; widen until the residual changes sign.
+    lower, upper = center * 0.5, center * 2.0
+    f_lower = aspect_at(lower) - target_aspect_ratio
+    f_upper = aspect_at(upper) - target_aspect_ratio
+    expansions = 0
+    while f_lower * f_upper > 0 and expansions < 10:
+        lower *= 0.5
+        upper *= 2.0
+        f_lower = aspect_at(lower) - target_aspect_ratio
+        f_upper = aspect_at(upper) - target_aspect_ratio
+        expansions += 1
+    if f_lower * f_upper > 0:
+        raise ValueError("Failed to bracket target aspect ratio via mode scaling.")
+
+    for _ in range(max_iterations):
+        mid = 0.5 * (lower + upper)
+        residual = aspect_at(mid) - target_aspect_ratio
+        if abs(residual) <= absolute_tolerance:
+            return _scale_poloidal_modes(surface, mid)
+        if residual * f_lower < 0:
+            upper, f_upper = mid, residual
+        else:
+            lower, f_lower = mid, residual
+
+    return _scale_poloidal_modes(surface, 0.5 * (lower + upper))
+
+
+def _scale_poloidal_modes(surface: SurfaceRZFourier, scale: float) -> SurfaceRZFourier:
+    """Return a copy of ``surface`` with all m != 0 Fourier modes scaled."""
+
+    def _scale(coeffs: FourierCoefficients) -> FourierCoefficients:
+        scaled = coeffs.copy()
+        scaled[1:, :] *= scale  # m = 0 row is untouched.
+        return scaled
+
+    r_cos = _scale(surface.r_cos)
+    z_sin = _scale(surface.z_sin)
+    r_sin = _scale(surface.r_sin) if surface.r_sin is not None else None
+    z_cos = _scale(surface.z_cos) if surface.z_cos is not None else None
+
+    return surface.model_copy(
+        update=dict(r_cos=r_cos, z_sin=z_sin, r_sin=r_sin, z_cos=z_cos)
+    )
+
+
 def evaluate_points_xyz(
     surface: SurfaceRZFourier, theta_phi: jt.Float[np.ndarray, "*dims 2"]
 ) -> jt.Float[np.ndarray, "*dims 3"]:

--- a/tests/geometry/surface_rz_fourier_test.py
+++ b/tests/geometry/surface_rz_fourier_test.py
@@ -1184,3 +1184,76 @@ def test_to_standard_orientation_torus_internal_cw() -> None:
     theta_phi_std[:, :, 0] = -theta_phi_std[:, :, 0] + np.pi
     points_std = surface_rz_fourier.evaluate_points_xyz(surface_std, theta_phi_std)
     np.testing.assert_allclose(points, points_std, atol=1e-12)
+
+
+# ---------- scale_to_aspect_ratio tests ----------
+
+
+def _rotating_ellipse(
+    major_radius: float, minor_radius: float
+) -> surface_rz_fourier.SurfaceRZFourier:
+    """A simple stellarator-symmetric NFP=3 rotating-ellipse boundary."""
+    r_cos = np.array(
+        [
+            [0.0, major_radius, 0.0],
+            [0.1, minor_radius, 0.05],
+        ]
+    )
+    z_sin = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.1, minor_radius, 0.05],
+        ]
+    )
+    return surface_rz_fourier.SurfaceRZFourier(
+        r_cos=r_cos,
+        z_sin=z_sin,
+        n_field_periods=3,
+        is_stellarator_symmetric=True,
+    )
+
+
+def test_scale_to_aspect_ratio_hits_target() -> None:
+    surface = _rotating_ellipse(major_radius=10.0, minor_radius=1.0)
+    for target in [6.0, 8.7, 11.7]:
+        rescaled = surface_rz_fourier.scale_to_aspect_ratio(
+            surface, target_aspect_ratio=target
+        )
+        assert abs(surface_rz_fourier.compute_aspect_ratio(rescaled) - target) < 1e-3
+
+
+def test_scale_to_aspect_ratio_preserves_m0_modes() -> None:
+    surface = _rotating_ellipse(major_radius=10.0, minor_radius=1.0)
+    rescaled = surface_rz_fourier.scale_to_aspect_ratio(
+        surface, target_aspect_ratio=12.0
+    )
+    np.testing.assert_array_equal(rescaled.r_cos[0, :], surface.r_cos[0, :])
+    np.testing.assert_array_equal(rescaled.z_sin[0, :], surface.z_sin[0, :])
+
+
+def test_scale_to_aspect_ratio_scales_m_nonzero_modes_by_a_single_factor() -> None:
+    surface = _rotating_ellipse(major_radius=10.0, minor_radius=1.0)
+    rescaled = surface_rz_fourier.scale_to_aspect_ratio(
+        surface, target_aspect_ratio=12.0
+    )
+    nonzero_mask = np.abs(surface.r_cos[1:, :]) > 1e-12
+    ratios = rescaled.r_cos[1:, :][nonzero_mask] / surface.r_cos[1:, :][nonzero_mask]
+    np.testing.assert_allclose(ratios, ratios[0], rtol=1e-12)
+
+
+def test_scale_to_aspect_ratio_rejects_non_positive_target() -> None:
+    surface = _rotating_ellipse(major_radius=10.0, minor_radius=1.0)
+    with pytest.raises(ValueError, match="target_aspect_ratio must be > 0"):
+        surface_rz_fourier.scale_to_aspect_ratio(surface, target_aspect_ratio=0.0)
+    with pytest.raises(ValueError, match="target_aspect_ratio must be > 0"):
+        surface_rz_fourier.scale_to_aspect_ratio(surface, target_aspect_ratio=-1.0)
+
+
+def test_scale_to_aspect_ratio_is_idempotent_when_target_equals_current() -> None:
+    surface = _rotating_ellipse(major_radius=10.0, minor_radius=1.0)
+    current_ar = surface_rz_fourier.compute_aspect_ratio(surface)
+    rescaled = surface_rz_fourier.scale_to_aspect_ratio(
+        surface, target_aspect_ratio=current_ar
+    )
+    np.testing.assert_allclose(rescaled.r_cos, surface.r_cos, rtol=1e-3, atol=1e-6)
+    np.testing.assert_allclose(rescaled.z_sin, surface.z_sin, rtol=1e-3, atol=1e-6)


### PR DESCRIPTION
Adds compute_aspect_ratio (via simsopt) and scale_to_aspect_ratio, which
rescales all m != 0 Fourier modes of a SurfaceRZFourier by a single factor
found by bisection so the resulting surface has the requested aspect ratio.
The major radius (m=n=0 mode) is preserved. Needed by the binned diversity
scorer, which normalizes all boundaries in an AR bin to that bin's center
before measuring shape distance.