### PR TITLE
Add symmetrized RMS normal displacement distance

### DIFF
--- a/src/constellaration/geometry/surface_rz_fourier.py
+++ b/src/constellaration/geometry/surface_rz_fourier.py
@@ -703,6 +703,52 @@ def compute_normal_displacement_distance(
     return float(0.5 * (average_forward_distance + average_backward_distance))
 
 
+def compute_rms_normal_displacement_distance(
+    surface_1: SurfaceRZFourier,
+    surface_2: SurfaceRZFourier,
+    n_poloidal_points: int = 32,
+    n_toroidal_points: int = 32,
+) -> float:
+    """Symmetrized RMS normal displacement distance between two surfaces.
+
+    For each surface, the signed normal distance to the other surface is
+    evaluated on a ``n_poloidal_points x n_toroidal_points`` grid and the RMS
+    is taken; the returned distance is the arithmetic mean of the two RMS
+    values, so that ``d(A, B) == d(B, A)``.
+
+    This is the geometric diversity metric used by the multi-objective
+    MHD-stable QI benchmark to score how shape-different two near-Pareto
+    boundaries are after normalizing them to a common aspect ratio. The
+    metric is non-negative, symmetric, and zero only when the two surfaces
+    coincide on the sampling grid.
+
+    Args:
+        surface_1: First surface.
+        surface_2: Second surface.
+        n_poloidal_points: Number of poloidal grid points used for evaluation.
+        n_toroidal_points: Number of toroidal grid points used for evaluation.
+
+    Returns:
+        The symmetrized RMS normal displacement distance between the two
+        surfaces.
+    """
+    forward_distances = compute_normal_displacement(
+        target_surface=surface_1,
+        comparison_surface=surface_2,
+        n_poloidal_points=n_poloidal_points,
+        n_toroidal_points=n_toroidal_points,
+    )
+    backward_distances = compute_normal_displacement(
+        target_surface=surface_2,
+        comparison_surface=surface_1,
+        n_poloidal_points=n_poloidal_points,
+        n_toroidal_points=n_toroidal_points,
+    )
+    rms_forward = jnp.sqrt(jnp.mean(forward_distances**2))
+    rms_backward = jnp.sqrt(jnp.mean(backward_distances**2))
+    return float(0.5 * (rms_forward + rms_backward))
+
+
 def set_max_mode_numbers(
     surface: SurfaceRZFourier,
     max_poloidal_mode: int,

--- a/tests/geometry/surface_rz_fourier_test.py
+++ b/tests/geometry/surface_rz_fourier_test.py
@@ -1257,3 +1257,95 @@ def test_scale_to_aspect_ratio_is_idempotent_when_target_equals_current() -> Non
     )
     np.testing.assert_allclose(rescaled.r_cos, surface.r_cos, rtol=1e-3, atol=1e-6)
     np.testing.assert_allclose(rescaled.z_sin, surface.z_sin, rtol=1e-3, atol=1e-6)
+
+
+# ---------- compute_rms_normal_displacement_distance tests ----------
+
+
+def test_rms_normal_displacement_distance_zero_for_identical_surfaces() -> None:
+    surface = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[3.0], [0.5]]),
+        z_sin=np.array([[0.0], [0.5]]),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    )
+    distance = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        surface_1=surface,
+        surface_2=surface,
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    assert distance == pytest.approx(0.0, abs=1e-12)
+
+
+def test_rms_normal_displacement_distance_is_symmetric() -> None:
+    a = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[3.0], [0.4]]),
+        z_sin=np.array([[0.0], [0.4]]),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    )
+    b = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[3.1], [0.5]]),
+        z_sin=np.array([[0.0], [0.5]]),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    )
+    d_ab = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        a, b, n_poloidal_points=8, n_toroidal_points=8
+    )
+    d_ba = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        b, a, n_poloidal_points=8, n_toroidal_points=8
+    )
+    assert d_ab == pytest.approx(d_ba, rel=1e-12)
+
+
+def test_rms_normal_displacement_distance_matches_radial_offset() -> None:
+    delta = 0.2
+    target_surface = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[3.0], [0.4]]),
+        z_sin=np.array([[0.0], [0.4]]),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    )
+    comparison_surface = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[3.0 + delta], [0.4]]),
+        z_sin=np.array([[0.0], [0.4]]),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    )
+    # For an axisymmetric horizontal offset, the signed normal projection
+    # equals delta * cos(theta) on the target, so RMS = delta / sqrt(2).
+    distance = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        target_surface,
+        comparison_surface,
+        n_poloidal_points=64,
+        n_toroidal_points=8,
+    )
+    assert distance == pytest.approx(delta / np.sqrt(2.0), rel=5e-2)
+
+
+def test_rms_normal_displacement_distance_differs_from_mean_abs_version() -> None:
+    # The new RMS version is not the same as the existing mean-abs version
+    # for non-uniform displacements: RMS >= mean(|.|) with equality only when
+    # the signed distances are constant. We construct surfaces whose
+    # displacement varies poloidally so the two metrics differ measurably.
+    a = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[3.0], [0.4]]),
+        z_sin=np.array([[0.0], [0.4]]),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    )
+    b = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[3.05], [0.6]]),  # different minor radius too
+        z_sin=np.array([[0.0], [0.6]]),
+        n_field_periods=1,
+        is_stellarator_symmetric=True,
+    )
+    rms = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        a, b, n_poloidal_points=32, n_toroidal_points=8
+    )
+    mean_abs = surface_rz_fourier.compute_normal_displacement_distance(
+        a, b, n_poloidal_points=32, n_toroidal_points=8
+    )
+    assert rms > mean_abs > 0


### PR DESCRIPTION
The existing compute_normal_displacement_distance averages absolute
signed distances. The contractor scoring spec (multi-objective MHD-stable
QI diversity score) instead uses the average of the two RMS values --
that is the metric used by the baseline diversity numbers we publish.
Adds compute_rms_normal_displacement_distance alongside (not replacing)
the existing function so neither the existing API nor its callers change.