### PR TITLE
Add Pareto-level enumeration and 90%-of-L0 HIV filter

### DIFF
--- a/src/constellaration/mhd_stable_qi_scoring.py
+++ b/src/constellaration/mhd_stable_qi_scoring.py
@@ -1,0 +1,134 @@
+"""Scoring utilities for the multi-objective MHD-stable QI benchmark.
+
+This module bundles the post-evaluation logic used by the contractor scoring
+pipeline of the multi-objective MHD-stable QI problem: enumerating successive
+Pareto levels in the ``(-lgradB, aspect_ratio)`` objective space and selecting
+the top levels whose hypervolume (HIV) stays above a fraction of the L0
+front's HIV. The functions accept generic 2D minimization objective arrays so
+they are also reusable for other multi-objective post-analyses.
+"""
+
+from __future__ import annotations
+
+import jaxtyping as jt
+import numpy as np
+from pymoo.indicators import hv
+
+
+def pareto_levels(
+    objectives: jt.Float[np.ndarray, "n_points n_objectives"],
+) -> list[np.ndarray]:
+    """Enumerate successive non-dominated Pareto levels (minimization).
+
+    A point ``i`` dominates ``j`` if ``objectives[i] <= objectives[j]``
+    componentwise and ``objectives[i] != objectives[j]``. Level 0 is the
+    non-dominated front of the input; level 1 is the non-dominated front
+    after removing level 0; and so on, until every point has been assigned.
+
+    Args:
+        objectives: ``(n_points, n_objectives)`` array; every column is
+            interpreted as a minimization objective.
+
+    Returns:
+        List of integer arrays of original indices, one per level, starting
+        with level 0.
+    """
+    if objectives.ndim != 2:
+        raise ValueError(
+            f"objectives must be 2D (n_points, n_objectives), got shape "
+            f"{objectives.shape}"
+        )
+    n_points = objectives.shape[0]
+    if n_points == 0:
+        return []
+
+    remaining = np.arange(n_points)
+    levels: list[np.ndarray] = []
+    while remaining.size:
+        front_mask = _non_dominated_mask(objectives[remaining])
+        levels.append(remaining[front_mask])
+        remaining = remaining[~front_mask]
+    return levels
+
+
+def _non_dominated_mask(
+    objectives: jt.Float[np.ndarray, "n_points n_objectives"],
+) -> np.ndarray:
+    """Boolean mask of non-dominated points (minimization)."""
+    n_points = objectives.shape[0]
+    is_non_dominated = np.ones(n_points, dtype=bool)
+    for i in range(n_points):
+        if not is_non_dominated[i]:
+            continue
+        dominates_i = np.all(objectives <= objectives[i], axis=1) & np.any(
+            objectives < objectives[i], axis=1
+        )
+        if np.any(dominates_i):
+            is_non_dominated[i] = False
+    return is_non_dominated
+
+
+def hypervolume(
+    objectives: jt.Float[np.ndarray, "n_points n_objectives"],
+    reference_point: jt.Float[np.ndarray, " n_objectives"],
+) -> float:
+    """Hypervolume dominated by ``objectives`` relative to ``reference_point``.
+
+    All objectives are minimized. Returns ``0.0`` for an empty input.
+    """
+    if objectives.shape[0] == 0:
+        return 0.0
+    indicator = hv.Hypervolume(ref_point=np.asarray(reference_point))
+    output = indicator(np.asarray(objectives))
+    assert output is not None
+    return float(output)
+
+
+def select_top_pareto_levels_by_hiv_fraction(
+    objectives: jt.Float[np.ndarray, "n_points n_objectives"],
+    reference_point: jt.Float[np.ndarray, " n_objectives"],
+    fraction: float = 0.9,
+) -> np.ndarray:
+    """Indices of points from the top Pareto levels worth keeping for diversity.
+
+    Mirrors the contractor SoW filter: enumerate Pareto levels of the
+    minimization-objective array, then keep levels ``0`` through ``K - 1``
+    where ``K`` is the smallest level such that ``HIV(levels[K:]) <
+    fraction * HIV(level 0)``. If no level satisfies the condition, every
+    level is kept. Level 0 is always included.
+
+    Args:
+        objectives: ``(n_points, n_objectives)`` minimization objective array.
+        reference_point: Reference point passed to the HIV indicator.
+        fraction: Inclusion threshold, default 0.9 (the value used by the
+            SoW baselines).
+
+    Returns:
+        Sorted array of selected point indices (into ``objectives``).
+    """
+    if not 0.0 < fraction <= 1.0:
+        raise ValueError(f"fraction must be in (0, 1], got {fraction}")
+
+    levels = pareto_levels(objectives)
+    if not levels:
+        return np.empty(0, dtype=int)
+
+    hiv_l0 = hypervolume(objectives[levels[0]], reference_point)
+    if hiv_l0 <= 0.0:
+        # L0 front does not dominate the reference point; nothing meaningful
+        # to compare against, so we just return L0.
+        return np.sort(levels[0])
+
+    k_threshold: int | None = None
+    for k in range(len(levels)):
+        remaining_indices = np.concatenate(levels[k:])
+        hiv_k = hypervolume(objectives[remaining_indices], reference_point)
+        if hiv_k < fraction * hiv_l0:
+            k_threshold = k
+            break
+
+    if k_threshold is None:
+        selected = np.concatenate(levels)
+    else:
+        selected = np.concatenate(levels[:k_threshold])
+    return np.sort(selected)

--- a/tests/mhd_stable_qi_scoring_test.py
+++ b/tests/mhd_stable_qi_scoring_test.py
@@ -1,0 +1,151 @@
+import numpy as np
+import pytest
+
+from constellaration import mhd_stable_qi_scoring
+
+
+def test_pareto_levels_empty_input() -> None:
+    levels = mhd_stable_qi_scoring.pareto_levels(np.empty((0, 2)))
+    assert levels == []
+
+
+def test_pareto_levels_single_point() -> None:
+    levels = mhd_stable_qi_scoring.pareto_levels(np.array([[0.0, 0.0]]))
+    assert len(levels) == 1
+    np.testing.assert_array_equal(levels[0], [0])
+
+
+def test_pareto_levels_two_objectives_clean_ordering() -> None:
+    # A=(0,3) and B=(3,0) trade off (neither dominates the other).
+    # C=(1,1) is dominated by neither A nor B, so it sits on L0 too.
+    # D=(2,2) is dominated by C, so it falls into L1.
+    objectives = np.array(
+        [
+            [0.0, 3.0],  # A
+            [3.0, 0.0],  # B
+            [1.0, 1.0],  # C
+            [2.0, 2.0],  # D
+        ]
+    )
+    levels = mhd_stable_qi_scoring.pareto_levels(objectives)
+    assert len(levels) == 2
+    np.testing.assert_array_equal(np.sort(levels[0]), [0, 1, 2])
+    np.testing.assert_array_equal(np.sort(levels[1]), [3])
+
+
+def test_pareto_levels_all_identical_points_one_level() -> None:
+    objectives = np.tile([1.0, 1.0], (5, 1))
+    levels = mhd_stable_qi_scoring.pareto_levels(objectives)
+    # Identical points don't strictly dominate each other, so all in L0.
+    assert len(levels) == 1
+    np.testing.assert_array_equal(np.sort(levels[0]), [0, 1, 2, 3, 4])
+
+
+def test_pareto_levels_partition_is_complete() -> None:
+    rng = np.random.default_rng(0)
+    objectives = rng.standard_normal((50, 2))
+    levels = mhd_stable_qi_scoring.pareto_levels(objectives)
+    all_indices = np.concatenate(levels)
+    np.testing.assert_array_equal(np.sort(all_indices), np.arange(50))
+    # No duplicates across levels.
+    assert len(set(all_indices.tolist())) == 50
+
+
+def test_hypervolume_zero_for_empty_set() -> None:
+    assert (
+        mhd_stable_qi_scoring.hypervolume(np.empty((0, 2)), np.array([1.0, 1.0])) == 0.0
+    )
+
+
+def test_hypervolume_matches_known_value_for_single_point() -> None:
+    # Reference (1, 1), point (0.4, 0.3) -> dominated rectangle 0.6 * 0.7 = 0.42
+    value = mhd_stable_qi_scoring.hypervolume(
+        np.array([[0.4, 0.3]]), np.array([1.0, 1.0])
+    )
+    assert value == pytest.approx(0.42)
+
+
+def test_select_top_pareto_levels_drops_levels_that_collapse_hiv() -> None:
+    # Three points form a true trade-off (none dominates another -> all in L0),
+    # and a fourth point dominated by them (-> L1). The L1 sub-front HIV is
+    # well below 0.9 * HIV(L0), so only L0 is kept.
+    objectives = np.array(
+        [
+            [-3.0, 8.0],  # L0: best lgradB, worst AR
+            [-2.0, 6.0],  # L0: mid trade-off
+            [-1.0, 4.0],  # L0: worst lgradB, best AR
+            [0.0, 10.0],  # L1: dominated by all three above
+        ]
+    )
+    ref = np.array([1.0, 20.0])
+    levels = mhd_stable_qi_scoring.pareto_levels(objectives)
+    # Sanity check on the input setup.
+    np.testing.assert_array_equal(np.sort(levels[0]), [0, 1, 2])
+    np.testing.assert_array_equal(np.sort(levels[1]), [3])
+    hiv_l0 = mhd_stable_qi_scoring.hypervolume(objectives[levels[0]], ref)
+    hiv_l1_only = mhd_stable_qi_scoring.hypervolume(objectives[levels[1]], ref)
+    assert hiv_l1_only < 0.9 * hiv_l0
+
+    selected = mhd_stable_qi_scoring.select_top_pareto_levels_by_hiv_fraction(
+        objectives, reference_point=ref, fraction=0.9
+    )
+    np.testing.assert_array_equal(selected, [0, 1, 2])
+
+
+def test_select_top_pareto_levels_includes_l1_when_almost_as_good() -> None:
+    # L0 is a trade-off front. L1 is a slightly-shifted copy of the same
+    # trade-off, so its sub-front HIV is comparable to L0 -- both should be
+    # kept (i.e. ratio >= 0.9).
+    objectives = np.array(
+        [
+            [-3.0, 8.0],  # L0
+            [-2.0, 6.0],  # L0
+            [-1.0, 4.0],  # L0
+            [-2.9, 8.5],  # L1: dominated only by (-3.0, 8.0)
+            [-1.9, 6.5],  # L1: dominated only by (-2.0, 6.0)
+            [-0.9, 4.5],  # L1: dominated only by (-1.0, 4.0)
+        ]
+    )
+    ref = np.array([1.0, 20.0])
+    levels = mhd_stable_qi_scoring.pareto_levels(objectives)
+    assert len(levels) == 2
+    hiv_l0 = mhd_stable_qi_scoring.hypervolume(objectives[levels[0]], ref)
+    hiv_l1 = mhd_stable_qi_scoring.hypervolume(objectives[levels[1]], ref)
+    # L1 is a small shift of L0 so it captures most of L0's HIV.
+    assert hiv_l1 >= 0.9 * hiv_l0
+
+    selected = mhd_stable_qi_scoring.select_top_pareto_levels_by_hiv_fraction(
+        objectives, reference_point=ref, fraction=0.9
+    )
+    # All six should be included.
+    np.testing.assert_array_equal(selected, [0, 1, 2, 3, 4, 5])
+
+
+def test_select_top_pareto_levels_rejects_invalid_fraction() -> None:
+    objectives = np.array([[-1.0, 5.0]])
+    ref = np.array([1.0, 20.0])
+    with pytest.raises(ValueError, match="fraction must be in"):
+        mhd_stable_qi_scoring.select_top_pareto_levels_by_hiv_fraction(
+            objectives, ref, fraction=0.0
+        )
+    with pytest.raises(ValueError, match="fraction must be in"):
+        mhd_stable_qi_scoring.select_top_pareto_levels_by_hiv_fraction(
+            objectives, ref, fraction=1.1
+        )
+
+
+def test_select_top_pareto_levels_handles_empty_input() -> None:
+    out = mhd_stable_qi_scoring.select_top_pareto_levels_by_hiv_fraction(
+        np.empty((0, 2)), np.array([1.0, 20.0])
+    )
+    assert out.size == 0
+
+
+def test_select_top_pareto_levels_handles_points_outside_reference() -> None:
+    # All points dominated by the reference -> L0 HIV is 0 -> just return L0.
+    objectives = np.array([[5.0, 25.0], [10.0, 30.0]])
+    selected = mhd_stable_qi_scoring.select_top_pareto_levels_by_hiv_fraction(
+        objectives, reference_point=np.array([1.0, 20.0])
+    )
+    # First arg's L0 is [0] (it dominates [1]); fall-back returns L0.
+    np.testing.assert_array_equal(selected, [0])


### PR DESCRIPTION
Introduces a new constellaration.mhd_stable_qi_scoring module with:

- pareto_levels: enumerate successive non-dominated fronts of a
minimization-objective array.
- hypervolume: pymoo-backed indicator wrapper with empty-input handling.
- select_top_pareto_levels_by_hiv_fraction: keep levels 0..K-1 where K is
the first level whose sub-front HIV drops below fraction * HIV(L0)(default fraction=0.9).

These utilities are used by the upcoming binned-diversity scorer to restrict
which configurations contribute to the diversity score.