### PR TITLE
Add binned diversity score (10 AR bins, top-15 by lgradB)

### DIFF
--- a/src/constellaration/mhd_stable_qi_scoring.py
+++ b/src/constellaration/mhd_stable_qi_scoring.py
@@ -10,9 +10,20 @@ they are also reusable for other multi-objective post-analyses.
 
 from __future__ import annotations
 
+import itertools
+
 import jaxtyping as jt
 import numpy as np
 from pymoo.indicators import hv
+
+from constellaration.geometry import surface_rz_fourier
+
+DEFAULT_AR_MIN = 6.0
+DEFAULT_AR_MAX = 12.0
+DEFAULT_N_BINS = 10
+DEFAULT_MAX_PER_BIN = 15
+DEFAULT_N_POLOIDAL_POINTS = 32
+DEFAULT_N_TOROIDAL_POINTS = 32
 
 
 def pareto_levels(
@@ -132,3 +143,112 @@ def select_top_pareto_levels_by_hiv_fraction(
     else:
         selected = np.concatenate(levels[:k_threshold])
     return np.sort(selected)
+
+
+def binned_diversity_score(
+    boundaries: list[surface_rz_fourier.SurfaceRZFourier],
+    aspect_ratios: jt.Float[np.ndarray, " n_points"],
+    lgradB_values: jt.Float[np.ndarray, " n_points"],
+    *,
+    ar_min: float = DEFAULT_AR_MIN,
+    ar_max: float = DEFAULT_AR_MAX,
+    n_bins: int = DEFAULT_N_BINS,
+    max_per_bin: int = DEFAULT_MAX_PER_BIN,
+    n_poloidal_points: int = DEFAULT_N_POLOIDAL_POINTS,
+    n_toroidal_points: int = DEFAULT_N_TOROIDAL_POINTS,
+) -> float:
+    """Binned geometric diversity score across the aspect-ratio range.
+
+    Bins ``aspect_ratios`` into ``n_bins`` equal-width bins spanning
+    ``[ar_min, ar_max]``. For each bin with at least two configurations, the
+    top ``max_per_bin`` boundaries by ``lgradB_values`` are normalized to the
+    bin center via :func:`surface_rz_fourier.scale_to_aspect_ratio`, and the
+    mean pairwise symmetrized RMS normal displacement distance is computed.
+    Bins with fewer than two configurations score zero. The overall score is
+    the arithmetic mean across **all** ``n_bins`` bins -- empty bins penalize
+    the score, rewarding coverage of the AR range.
+
+    Args:
+        boundaries: Plasma boundaries (one per submitted configuration).
+        aspect_ratios: Aspect ratio of each boundary (typically from the
+            forward-model metrics).
+        lgradB_values: ``min_normalized_magnetic_gradient_scale_length``
+            (already multiplied by ``n_field_periods``) for each boundary.
+            Used to pick the top ``max_per_bin`` per bin.
+        ar_min: Lower edge of the binning range.
+        ar_max: Upper edge of the binning range.
+        n_bins: Number of equal-width bins.
+        max_per_bin: Per-bin cap on the number of boundaries used to
+            compute pairwise distances.
+        n_poloidal_points: Poloidal grid resolution for the distance metric.
+        n_toroidal_points: Toroidal grid resolution for the distance metric.
+
+    Returns:
+        Mean diversity score across the ``n_bins`` bins.
+    """
+    n = len(boundaries)
+    if len(aspect_ratios) != n or len(lgradB_values) != n:
+        raise ValueError(
+            "boundaries, aspect_ratios and lgradB_values must have the same length"
+        )
+    if n_bins <= 0:
+        raise ValueError(f"n_bins must be positive, got {n_bins}")
+    if ar_max <= ar_min:
+        raise ValueError(f"ar_max must exceed ar_min, got [{ar_min}, {ar_max}]")
+    if max_per_bin < 2:
+        raise ValueError(f"max_per_bin must be >= 2, got {max_per_bin}")
+
+    bin_width = (ar_max - ar_min) / n_bins
+    bin_centers = ar_min + (np.arange(n_bins) + 0.5) * bin_width
+
+    aspect_ratios = np.asarray(aspect_ratios)
+    lgradB_values = np.asarray(lgradB_values)
+
+    bin_scores = np.zeros(n_bins)
+    for bin_idx in range(n_bins):
+        bin_low = ar_min + bin_idx * bin_width
+        bin_high = bin_low + bin_width
+        if bin_idx == n_bins - 1:
+            mask = (aspect_ratios >= bin_low) & (aspect_ratios <= bin_high)
+        else:
+            mask = (aspect_ratios >= bin_low) & (aspect_ratios < bin_high)
+        member_indices = np.flatnonzero(mask)
+        if member_indices.size < 2:
+            continue
+
+        # Keep the top `max_per_bin` by lgradB (higher is better).
+        sorted_idx = member_indices[np.argsort(-lgradB_values[member_indices])]
+        kept = sorted_idx[:max_per_bin]
+
+        normalized = [
+            surface_rz_fourier.scale_to_aspect_ratio(
+                boundaries[int(i)], target_aspect_ratio=float(bin_centers[bin_idx])
+            )
+            for i in kept
+        ]
+        bin_scores[bin_idx] = _mean_pairwise_rms_distance(
+            normalized,
+            n_poloidal_points=n_poloidal_points,
+            n_toroidal_points=n_toroidal_points,
+        )
+
+    return float(np.mean(bin_scores))
+
+
+def _mean_pairwise_rms_distance(
+    boundaries: list[surface_rz_fourier.SurfaceRZFourier],
+    n_poloidal_points: int,
+    n_toroidal_points: int,
+) -> float:
+    """Mean over all unordered pairs of the symmetrized RMS normal distance."""
+    distances: list[float] = []
+    for a, b in itertools.combinations(boundaries, 2):
+        distances.append(
+            surface_rz_fourier.compute_rms_normal_displacement_distance(
+                a,
+                b,
+                n_poloidal_points=n_poloidal_points,
+                n_toroidal_points=n_toroidal_points,
+            )
+        )
+    return float(np.mean(distances))

--- a/tests/mhd_stable_qi_scoring_test.py
+++ b/tests/mhd_stable_qi_scoring_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from constellaration import mhd_stable_qi_scoring
+from constellaration.geometry import surface_rz_fourier
 
 
 def test_pareto_levels_empty_input() -> None:
@@ -149,3 +150,151 @@ def test_select_top_pareto_levels_handles_points_outside_reference() -> None:
     )
     # First arg's L0 is [0] (it dominates [1]); fall-back returns L0.
     np.testing.assert_array_equal(selected, [0])
+
+
+# ---------- binned_diversity_score tests ----------
+
+
+def _rotating_ellipse_at_ar(
+    target_ar: float, triangularity: float = 0.0
+) -> surface_rz_fourier.SurfaceRZFourier:
+    """Build a stellarator-symmetric NFP=3 surface then scale to target AR."""
+    r_cos = np.array(
+        [
+            [0.0, 10.0, 0.0],
+            [0.1, 1.0, triangularity],
+        ]
+    )
+    z_sin = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.1, 1.0, triangularity],
+        ]
+    )
+    surface = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=r_cos,
+        z_sin=z_sin,
+        n_field_periods=3,
+        is_stellarator_symmetric=True,
+    )
+    return surface_rz_fourier.scale_to_aspect_ratio(
+        surface, target_aspect_ratio=target_ar
+    )
+
+
+def test_binned_diversity_empty_input_is_zero() -> None:
+    score = mhd_stable_qi_scoring.binned_diversity_score(
+        boundaries=[],
+        aspect_ratios=np.array([]),
+        lgradB_values=np.array([]),
+    )
+    assert score == 0.0
+
+
+def test_binned_diversity_score_validates_length_mismatch() -> None:
+    b = _rotating_ellipse_at_ar(7.0)
+    with pytest.raises(ValueError, match="same length"):
+        mhd_stable_qi_scoring.binned_diversity_score(
+            boundaries=[b, b],
+            aspect_ratios=np.array([7.0]),
+            lgradB_values=np.array([1.0, 2.0]),
+        )
+
+
+def test_binned_diversity_score_zero_when_single_point_per_bin() -> None:
+    # One configuration per bin -> every bin scores 0 -> overall score 0.
+    boundaries = [_rotating_ellipse_at_ar(ar) for ar in [6.3, 6.9, 7.5]]
+    score = mhd_stable_qi_scoring.binned_diversity_score(
+        boundaries=boundaries,
+        aspect_ratios=np.array([6.3, 6.9, 7.5]),
+        lgradB_values=np.array([1.0, 1.0, 1.0]),
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    assert score == 0.0
+
+
+def test_binned_diversity_score_drops_boundaries_outside_range() -> None:
+    # Two boundaries inside one bin, two outside the global range.
+    boundaries = [
+        _rotating_ellipse_at_ar(6.4, triangularity=0.0),
+        _rotating_ellipse_at_ar(6.4, triangularity=0.1),
+        _rotating_ellipse_at_ar(4.0),  # outside ar_min
+        _rotating_ellipse_at_ar(15.0),  # outside ar_max
+    ]
+    score = mhd_stable_qi_scoring.binned_diversity_score(
+        boundaries=boundaries,
+        aspect_ratios=np.array([6.4, 6.4, 4.0, 15.0]),
+        lgradB_values=np.array([1.0, 1.0, 1.0, 1.0]),
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    # One non-empty bin out of ten -> score is positive but small.
+    assert 0.0 < score < 1.0
+    # Score / n_bins must equal the within-bin distance / n_bins.
+    # i.e. bin 0 distance = 10 * score.
+    bin_distance = score * 10
+    assert bin_distance > 0
+
+
+def test_binned_diversity_score_returns_average_over_all_bins() -> None:
+    # Populate two bins each with two slightly-different boundaries; the
+    # other 8 bins are empty. Final score = (d_bin1 + d_bin2) / 10.
+    boundaries = [
+        _rotating_ellipse_at_ar(6.3, triangularity=0.0),
+        _rotating_ellipse_at_ar(6.3, triangularity=0.1),
+        _rotating_ellipse_at_ar(9.3, triangularity=0.0),
+        _rotating_ellipse_at_ar(9.3, triangularity=0.15),
+    ]
+    score = mhd_stable_qi_scoring.binned_diversity_score(
+        boundaries=boundaries,
+        aspect_ratios=np.array([6.3, 6.3, 9.3, 9.3]),
+        lgradB_values=np.array([1.0, 1.0, 1.0, 1.0]),
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    # Manually compute each bin's mean pairwise distance.
+    d_bin1 = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        boundaries[0], boundaries[1], n_poloidal_points=8, n_toroidal_points=8
+    )
+    d_bin2 = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        boundaries[2], boundaries[3], n_poloidal_points=8, n_toroidal_points=8
+    )
+    expected = (d_bin1 + d_bin2) / 10.0
+    assert score == pytest.approx(expected, rel=1e-3)
+
+
+def test_binned_diversity_score_caps_per_bin_using_lgradB() -> None:
+    # Three boundaries in the same bin, max_per_bin=2 -> only the two with
+    # the highest lgradB are kept (the unique boundary is dropped).
+    triangs = [0.0, 0.1, 0.2]
+    boundaries = [_rotating_ellipse_at_ar(7.5, triangularity=t) for t in triangs]
+    score_all = mhd_stable_qi_scoring.binned_diversity_score(
+        boundaries=boundaries,
+        aspect_ratios=np.array([7.5, 7.5, 7.5]),
+        lgradB_values=np.array([1.0, 2.0, 3.0]),
+        n_bins=1,
+        ar_min=7.2,
+        ar_max=7.8,
+        max_per_bin=15,
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    score_capped = mhd_stable_qi_scoring.binned_diversity_score(
+        boundaries=boundaries,
+        aspect_ratios=np.array([7.5, 7.5, 7.5]),
+        lgradB_values=np.array([1.0, 2.0, 3.0]),
+        n_bins=1,
+        ar_min=7.2,
+        ar_max=7.8,
+        max_per_bin=2,
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    expected_capped = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        boundaries[1], boundaries[2], n_poloidal_points=8, n_toroidal_points=8
+    )
+    assert score_capped == pytest.approx(expected_capped, rel=1e-3)
+    # The all-three average should differ from the top-2-only average since
+    # the dropped pair has a different distance.
+    assert score_all != pytest.approx(score_capped, rel=1e-3)


### PR DESCRIPTION
Adds binned_diversity_score to constellaration.mhd_stable_qi_scoring,
for the multi-objective MHD-stable QI diversity
metric:

- 10 equal-width aspect-ratio bins spanning [6.0, 12.0] by default
- each bin keeps the top max_per_bin=15 boundaries by lgradB
- each kept boundary is rescaled to the bin center via
scale_to_aspect_ratio
- bin score = mean over unordered pairs of the symmetrized RMS normal
displacement distance
- bins with < 2 configurations score 0; final score is the arithmetic
mean across all 10 bins, so empty bins penalize coverage

Boundaries outside [ar_min, ar_max] are silently dropped from the diversity
computation. The wrapper that runs the forward model and applies the L0-HIV
filter to choose which boundaries feed this function is added in a
follow-up.