### PR TITLE
Add score_boundaries_performance and score_boundaries_diversity

### DIFF
--- a/src/constellaration/mhd_stable_qi_scoring.py
+++ b/src/constellaration/mhd_stable_qi_scoring.py
@@ -11,12 +11,16 @@ they are also reusable for other multi-objective post-analyses.
 from __future__ import annotations
 
 import itertools
+from typing import Literal
 
 import jaxtyping as jt
 import numpy as np
 from pymoo.indicators import hv
 
+from constellaration import forward_model, problems
 from constellaration.geometry import surface_rz_fourier
+
+TightnessLevel = Literal["tight", "medium", "loose"]
 
 DEFAULT_AR_MIN = 6.0
 DEFAULT_AR_MAX = 12.0
@@ -24,6 +28,39 @@ DEFAULT_N_BINS = 10
 DEFAULT_MAX_PER_BIN = 15
 DEFAULT_N_POLOIDAL_POINTS = 32
 DEFAULT_N_TOROIDAL_POINTS = 32
+
+REFERENCE_POINT_LGRADB_AR = np.array([1.0, 20.0])
+"""HIV reference point in ``(-lgradB, aspect_ratio)`` minimization space."""
+
+DEFAULT_INCLUSION_HIV_FRACTION = 0.9
+"""Fraction of L0 HIV at which to stop including sub-fronts for diversity."""
+
+
+def problem_for_tightness_level(
+    tightness_level: TightnessLevel,
+) -> problems.MHDStableQIStellarator:
+    """Return the MHD-stable QI problem instance for the given tightness level."""
+    if tightness_level == "tight":
+        return problems.MHDStableQIStellarator()
+    if tightness_level == "medium":
+        return problems.MHDStableQIStellaratorMedium()
+    if tightness_level == "loose":
+        return problems.MHDStableQIStellaratorLoose()
+    raise ValueError(
+        f"tightness_level must be 'tight', 'medium' or 'loose', got "
+        f"{tightness_level!r}"
+    )
+
+
+def _compute_metrics(
+    boundaries: list[surface_rz_fourier.SurfaceRZFourier],
+) -> list[forward_model.ConstellarationMetrics]:
+    settings = forward_model.ConstellarationSettings.default_high_fidelity()
+    out: list[forward_model.ConstellarationMetrics] = []
+    for boundary in boundaries:
+        metrics, _ = forward_model.forward_model(boundary=boundary, settings=settings)
+        out.append(metrics)
+    return out
 
 
 def pareto_levels(
@@ -252,3 +289,140 @@ def _mean_pairwise_rms_distance(
             )
         )
     return float(np.mean(distances))
+
+
+def score_boundaries_performance(
+    boundaries: list[surface_rz_fourier.SurfaceRZFourier],
+    tightness_level: TightnessLevel,
+    *,
+    metrics: list[forward_model.ConstellarationMetrics] | None = None,
+) -> float:
+    """Hypervolume (HIV) of the feasible submitted boundaries at a tightness level.
+
+    Runs the constellaration forward model at high fidelity on every boundary
+    (unless precomputed ``metrics`` are passed), filters the configurations
+    feasible at ``tightness_level``, and returns the hypervolume of their
+    non-dominated front in ``(-lgradB, aspect_ratio)`` space relative to the
+    reference point ``(1.0, 20.0)``. Higher is better. Empty / all-infeasible
+    submissions score 0.
+
+    Args:
+        boundaries: Submitted plasma boundaries.
+        tightness_level: One of ``"tight"``, ``"medium"``, ``"loose"``.
+        metrics: Optional pre-computed forward-model metrics aligned with
+            ``boundaries``. Useful for repeated scoring without re-running
+            VMEC. If omitted, the forward model is invoked.
+
+    Returns:
+        Hypervolume score (a non-negative float).
+    """
+    problem = problem_for_tightness_level(tightness_level)
+    if metrics is None:
+        metrics = _compute_metrics(boundaries)
+    if len(metrics) != len(boundaries):
+        raise ValueError(
+            "metrics must have the same length as boundaries when provided"
+        )
+
+    feasible_metrics = [m for m in metrics if problem.is_feasible(m)]
+    if not feasible_metrics:
+        return 0.0
+    objectives = np.array(
+        [
+            (
+                -1.0 * m.minimum_normalized_magnetic_gradient_scale_length,
+                1.0 * m.aspect_ratio,
+            )
+            for m in feasible_metrics
+        ]
+    )
+    return hypervolume(objectives, REFERENCE_POINT_LGRADB_AR)
+
+
+def score_boundaries_diversity(
+    boundaries: list[surface_rz_fourier.SurfaceRZFourier],
+    tightness_level: TightnessLevel,
+    *,
+    metrics: list[forward_model.ConstellarationMetrics] | None = None,
+    inclusion_hiv_fraction: float = DEFAULT_INCLUSION_HIV_FRACTION,
+    ar_min: float = DEFAULT_AR_MIN,
+    ar_max: float = DEFAULT_AR_MAX,
+    n_bins: int = DEFAULT_N_BINS,
+    max_per_bin: int = DEFAULT_MAX_PER_BIN,
+    n_poloidal_points: int = DEFAULT_N_POLOIDAL_POINTS,
+    n_toroidal_points: int = DEFAULT_N_TOROIDAL_POINTS,
+) -> float:
+    """Binned geometric diversity score for boundaries near the Pareto front.
+
+    Pipeline:
+      1. Evaluate the forward model on each boundary at high fidelity
+         (unless ``metrics`` are passed).
+      2. Keep only configurations feasible at ``tightness_level``.
+      3. Compute successive Pareto levels in
+         ``(-lgradB, aspect_ratio)``-minimization space and keep the top
+         levels whose cumulative sub-front HIV stays at or above
+         ``inclusion_hiv_fraction * HIV(L0)`` (default ``0.9 * HIV(L0)``).
+      4. Score those near-optimal boundaries via
+         :func:`binned_diversity_score`: 10 AR bins from 6 to 12, top-15 by
+         lgradB per bin, mean pairwise symmetrized RMS normal-displacement
+         distance averaged across all bins (empty bins score 0).
+
+    Args:
+        boundaries: Submitted plasma boundaries.
+        tightness_level: One of ``"tight"``, ``"medium"``, ``"loose"``.
+        metrics: Optional pre-computed forward-model metrics aligned with
+            ``boundaries``.
+        inclusion_hiv_fraction: HIV-fraction-of-L0 cutoff for Pareto-level
+            inclusion. SoW default 0.9.
+        ar_min, ar_max, n_bins, max_per_bin, n_poloidal_points,
+            n_toroidal_points: Forwarded to :func:`binned_diversity_score`.
+
+    Returns:
+        Diversity score (a non-negative float).
+    """
+    problem = problem_for_tightness_level(tightness_level)
+    if metrics is None:
+        metrics = _compute_metrics(boundaries)
+    if len(metrics) != len(boundaries):
+        raise ValueError(
+            "metrics must have the same length as boundaries when provided"
+        )
+
+    feasible: list[tuple[surface_rz_fourier.SurfaceRZFourier, float, float]] = []
+    for boundary, m in zip(boundaries, metrics):
+        if problem.is_feasible(m):
+            feasible.append(
+                (
+                    boundary,
+                    m.minimum_normalized_magnetic_gradient_scale_length,
+                    m.aspect_ratio,
+                )
+            )
+    if len(feasible) < 2:
+        return 0.0
+
+    feasible_boundaries = [item[0] for item in feasible]
+    lgradB_arr = np.array([item[1] for item in feasible])
+    ar_arr = np.array([item[2] for item in feasible])
+    objectives = np.column_stack([-lgradB_arr, ar_arr])
+
+    selected = select_top_pareto_levels_by_hiv_fraction(
+        objectives,
+        reference_point=REFERENCE_POINT_LGRADB_AR,
+        fraction=inclusion_hiv_fraction,
+    )
+    if selected.size < 2:
+        return 0.0
+
+    selected_boundaries = [feasible_boundaries[int(i)] for i in selected]
+    return binned_diversity_score(
+        boundaries=selected_boundaries,
+        aspect_ratios=ar_arr[selected],
+        lgradB_values=lgradB_arr[selected],
+        ar_min=ar_min,
+        ar_max=ar_max,
+        n_bins=n_bins,
+        max_per_bin=max_per_bin,
+        n_poloidal_points=n_poloidal_points,
+        n_toroidal_points=n_toroidal_points,
+    )

--- a/tests/mhd_stable_qi_scoring_test.py
+++ b/tests/mhd_stable_qi_scoring_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from constellaration import mhd_stable_qi_scoring
+from constellaration import forward_model, mhd_stable_qi_scoring, problems
 from constellaration.geometry import surface_rz_fourier
 
 
@@ -298,3 +298,213 @@ def test_binned_diversity_score_caps_per_bin_using_lgradB() -> None:
     # The all-three average should differ from the top-2-only average since
     # the dropped pair has a different distance.
     assert score_all != pytest.approx(score_capped, rel=1e-3)
+
+
+# ---------- top-level scoring API ----------
+
+
+def _make_metrics(
+    aspect_ratio: float,
+    lgradB: float,
+) -> forward_model.ConstellarationMetrics:
+    """Return a ConstellarationMetrics that is feasible at all tightness levels."""
+    base = dict(
+        aspect_ratio=aspect_ratio,
+        axis_magnetic_mirror_ratio=0.1,
+        aspect_ratio_over_edge_rotational_transform=8.0,
+        axis_rotational_transform_over_n_field_periods=0.2,
+        average_triangularity=-0.6,
+        edge_rotational_transform_over_n_field_periods=0.30,
+        max_elongation=4.0,
+        qi=1e-5,  # log10 = -5, well below -3.5
+        edge_magnetic_mirror_ratio=0.1,
+        flux_compression_in_regions_of_bad_curvature=0.5,
+        vacuum_well=0.1,
+        minimum_normalized_magnetic_gradient_scale_length=lgradB,
+    )
+    return forward_model.ConstellarationMetrics(**base)
+
+
+def test_problem_for_tightness_level_returns_correct_classes() -> None:
+    assert isinstance(
+        mhd_stable_qi_scoring.problem_for_tightness_level("tight"),
+        problems.MHDStableQIStellarator,
+    )
+    assert isinstance(
+        mhd_stable_qi_scoring.problem_for_tightness_level("medium"),
+        problems.MHDStableQIStellaratorMedium,
+    )
+    assert isinstance(
+        mhd_stable_qi_scoring.problem_for_tightness_level("loose"),
+        problems.MHDStableQIStellaratorLoose,
+    )
+    with pytest.raises(ValueError, match="tightness_level"):
+        mhd_stable_qi_scoring.problem_for_tightness_level("absurd")  # type: ignore[arg-type]
+
+
+def test_score_boundaries_performance_with_precomputed_metrics() -> None:
+    # Three feasible points forming a trade-off, plus one infeasible.
+    boundaries = [
+        _rotating_ellipse_at_ar(7.0),
+        _rotating_ellipse_at_ar(9.0),
+        _rotating_ellipse_at_ar(11.0),
+        _rotating_ellipse_at_ar(8.0),  # will be made infeasible
+    ]
+    metrics = [
+        _make_metrics(7.0, 3.0),
+        _make_metrics(9.0, 5.0),
+        _make_metrics(11.0, 7.0),
+        _make_metrics(8.0, 4.0).model_copy(
+            update=dict(flux_compression_in_regions_of_bad_curvature=2.0)
+        ),
+    ]
+    score = mhd_stable_qi_scoring.score_boundaries_performance(
+        boundaries, "tight", metrics=metrics
+    )
+    # Should equal the HIV of the 3 feasible points (the 4th is infeasible).
+    feasible_objs = np.array(
+        [
+            (-3.0, 7.0),
+            (-5.0, 9.0),
+            (-7.0, 11.0),
+        ]
+    )
+    expected = mhd_stable_qi_scoring.hypervolume(
+        feasible_objs, mhd_stable_qi_scoring.REFERENCE_POINT_LGRADB_AR
+    )
+    assert score == pytest.approx(expected, rel=1e-9)
+
+
+def test_score_boundaries_performance_returns_zero_when_no_feasible() -> None:
+    boundaries = [_rotating_ellipse_at_ar(8.0)]
+    metrics = [
+        _make_metrics(8.0, 4.0).model_copy(
+            update=dict(flux_compression_in_regions_of_bad_curvature=5.0)
+        )
+    ]
+    score = mhd_stable_qi_scoring.score_boundaries_performance(
+        boundaries, "tight", metrics=metrics
+    )
+    assert score == 0.0
+
+
+def test_score_boundaries_performance_loose_admits_more_than_tight() -> None:
+    # A configuration violating Tight constraints but satisfying Loose.
+    boundaries = [_rotating_ellipse_at_ar(8.0)]
+    metrics = [
+        _make_metrics(8.0, 4.0).model_copy(
+            update=dict(
+                # vacuum_well -0.04 -> fails tight (>=0) and medium (>=-0.025)
+                # but passes loose (>=-0.05).
+                vacuum_well=-0.04,
+            )
+        )
+    ]
+    tight = mhd_stable_qi_scoring.score_boundaries_performance(
+        boundaries, "tight", metrics=metrics
+    )
+    medium = mhd_stable_qi_scoring.score_boundaries_performance(
+        boundaries, "medium", metrics=metrics
+    )
+    loose = mhd_stable_qi_scoring.score_boundaries_performance(
+        boundaries, "loose", metrics=metrics
+    )
+    assert tight == 0.0
+    assert medium == 0.0
+    assert loose > 0.0
+
+
+def test_score_boundaries_performance_validates_metrics_length() -> None:
+    boundaries = [_rotating_ellipse_at_ar(7.0), _rotating_ellipse_at_ar(8.0)]
+    metrics = [_make_metrics(7.0, 3.0)]  # mismatched length
+    with pytest.raises(ValueError, match="same length"):
+        mhd_stable_qi_scoring.score_boundaries_performance(
+            boundaries, "tight", metrics=metrics
+        )
+
+
+def test_score_boundaries_diversity_returns_zero_with_too_few_feasible() -> None:
+    boundaries = [_rotating_ellipse_at_ar(7.0)]
+    metrics = [_make_metrics(7.0, 3.0)]
+    assert (
+        mhd_stable_qi_scoring.score_boundaries_diversity(
+            boundaries, "tight", metrics=metrics
+        )
+        == 0.0
+    )
+
+
+def test_score_boundaries_diversity_matches_binned_score_on_included_set() -> None:
+    # 4 feasible boundaries: 2 in bin 6.3, 2 in bin 9.3. All in L0 (different
+    # trade-offs), so the HIV filter keeps all of them.
+    boundaries = [
+        _rotating_ellipse_at_ar(6.3, triangularity=0.0),
+        _rotating_ellipse_at_ar(6.3, triangularity=0.1),
+        _rotating_ellipse_at_ar(9.3, triangularity=0.0),
+        _rotating_ellipse_at_ar(9.3, triangularity=0.15),
+    ]
+    metrics = [
+        _make_metrics(6.3, 3.0),
+        _make_metrics(6.3, 2.9),
+        _make_metrics(9.3, 5.0),
+        _make_metrics(9.3, 4.9),
+    ]
+    score = mhd_stable_qi_scoring.score_boundaries_diversity(
+        boundaries,
+        "tight",
+        metrics=metrics,
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    # Manually compute the expected per-bin distances.
+    d_bin1 = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        boundaries[0], boundaries[1], n_poloidal_points=8, n_toroidal_points=8
+    )
+    d_bin2 = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        boundaries[2], boundaries[3], n_poloidal_points=8, n_toroidal_points=8
+    )
+    expected = (d_bin1 + d_bin2) / 10.0
+    assert score == pytest.approx(expected, rel=1e-3)
+
+
+def test_score_boundaries_diversity_drops_dominated_levels_via_hiv_filter() -> None:
+    # Add a dominated configuration in a third bin. With the default 90%
+    # filter it should be dropped, so the bin score for that third bin is 0
+    # and the overall score matches the two-bin case.
+    boundaries = [
+        _rotating_ellipse_at_ar(6.3, triangularity=0.0),
+        _rotating_ellipse_at_ar(6.3, triangularity=0.1),
+        _rotating_ellipse_at_ar(9.3, triangularity=0.0),
+        _rotating_ellipse_at_ar(9.3, triangularity=0.15),
+        # A duplicated point in another bin, but dominated by all of the
+        # above (worse lgradB AND worse AR -- AR farther from 6 than 9.3
+        # is 11.7, and we give it very low lgradB so it's dominated).
+        _rotating_ellipse_at_ar(11.7, triangularity=0.0),
+        _rotating_ellipse_at_ar(11.7, triangularity=0.2),
+    ]
+    metrics = [
+        _make_metrics(6.3, 3.0),
+        _make_metrics(6.3, 2.9),
+        _make_metrics(9.3, 5.0),
+        _make_metrics(9.3, 4.9),
+        # Very low lgradB AND high AR -> dominated by all others above.
+        _make_metrics(11.7, 0.1),
+        _make_metrics(11.7, 0.05),
+    ]
+    score = mhd_stable_qi_scoring.score_boundaries_diversity(
+        boundaries,
+        "tight",
+        metrics=metrics,
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    # Compare to score without the dominated bin: should be approximately
+    # equal because the HIV filter drops the dominated points.
+    score_no_dom = mhd_stable_qi_scoring.score_boundaries_diversity(
+        boundaries[:4],
+        "tight",
+        metrics=metrics[:4],
+        n_poloidal_points=8,
+        n_toroidal_points=8,
+    )
+    assert score == pytest.approx(score_no_dom, rel=1e-9)


### PR DESCRIPTION
These are the two public entry points to
score a submitted set of boundaries at a given tightness level
('tight' | 'medium' | 'loose').

- score_boundaries_performance(boundaries, level): runs the constellaration
forward model at high fidelity, filters for feasibility at the given
level, and returns the hypervolume of the feasible front in
(-lgradB, aspect_ratio) space with reference point (1.0, 20.0).
- score_boundaries_diversity(boundaries, level): same forward-model and
feasibility filtering, then keeps the top Pareto levels whose
cumulative sub-front HIV stays >= 90% of L0 HIV (configurable), and
feeds those near-optimal boundaries into binned_diversity_score.

Both functions accept an optional pre-computed metrics list, so users that
already have ConstellarationMetrics can score without re-running VMEC.