### PR TITLE
Make diversity distance invariant under stellarator-symmetric relabelings

### DIFF
--- a/src/constellaration/geometry/surface_rz_fourier.py
+++ b/src/constellaration/geometry/surface_rz_fourier.py
@@ -708,6 +708,7 @@ def compute_rms_normal_displacement_distance(
     surface_2: SurfaceRZFourier,
     n_poloidal_points: int = 32,
     n_toroidal_points: int = 32,
+    compare_augmentations: bool = True,
 ) -> float:
     """Symmetrized RMS normal displacement distance between two surfaces.
 
@@ -716,22 +717,69 @@ def compute_rms_normal_displacement_distance(
     is taken; the returned distance is the arithmetic mean of the two RMS
     values, so that ``d(A, B) == d(B, A)``.
 
-    This is the geometric diversity metric used by the multi-objective
-    MHD-stable QI benchmark to score how shape-different two near-Pareto
-    boundaries are after normalizing them to a common aspect ratio. The
-    metric is non-negative, symmetric, and zero only when the two surfaces
-    coincide on the sampling grid.
+    By default the distance is taken as the **minimum over all 8 x 8 = 64
+    pairs** of stellarator-symmetric augmentations of the two surfaces (see
+    :func:`generate_stellarator_symmetric_augmentation`). The 8 augmentations
+    of a stellarator-symmetric surface are sign flips of (1) ``z_sin``
+    coefficients, (2) odd toroidal modes, (3) odd poloidal modes; for a
+    well-resolved stellarator-symmetric configuration these all correspond
+    to the same physical shape under coordinate relabeling. Comparing all
+    augmentations prevents the diversity score from being inflated by
+    trivial symmetry relabelings that leave the physics unchanged. Set
+    ``compare_augmentations=False`` to recover the plain pairwise distance
+    (e.g. when ``surface_1`` or ``surface_2`` is not stellarator-symmetric,
+    or when the caller has already canonicalized the augmentation).
 
     Args:
         surface_1: First surface.
         surface_2: Second surface.
         n_poloidal_points: Number of poloidal grid points used for evaluation.
         n_toroidal_points: Number of toroidal grid points used for evaluation.
+        compare_augmentations: If True (default), return the minimum RMS
+            distance across all 64 (aug(surface_1), aug(surface_2)) pairs.
+            Falls back automatically to the plain pairwise distance when
+            either surface is not stellarator-symmetric.
 
     Returns:
         The symmetrized RMS normal displacement distance between the two
         surfaces.
     """
+    can_augment = (
+        compare_augmentations
+        and surface_1.is_stellarator_symmetric
+        and surface_2.is_stellarator_symmetric
+    )
+    if not can_augment:
+        return _pairwise_rms_normal_displacement(
+            surface_1,
+            surface_2,
+            n_poloidal_points=n_poloidal_points,
+            n_toroidal_points=n_toroidal_points,
+        )
+
+    best = float("inf")
+    for switches in _STELLARATOR_SYMMETRY_AUGMENTATION_SWITCHES:
+        aug_2 = generate_stellarator_symmetric_augmentation(
+            surface_2, augmentation_switches=list(switches)
+        )
+        candidate = _pairwise_rms_normal_displacement(
+            surface_1,
+            aug_2,
+            n_poloidal_points=n_poloidal_points,
+            n_toroidal_points=n_toroidal_points,
+        )
+        if candidate < best:
+            best = candidate
+    return best
+
+
+def _pairwise_rms_normal_displacement(
+    surface_1: SurfaceRZFourier,
+    surface_2: SurfaceRZFourier,
+    n_poloidal_points: int,
+    n_toroidal_points: int,
+) -> float:
+    """Plain symmetrized RMS normal displacement (no augmentation search)."""
     forward_distances = compute_normal_displacement(
         target_surface=surface_1,
         comparison_surface=surface_2,
@@ -747,6 +795,24 @@ def compute_rms_normal_displacement_distance(
     rms_forward = jnp.sqrt(jnp.mean(forward_distances**2))
     rms_backward = jnp.sqrt(jnp.mean(backward_distances**2))
     return float(0.5 * (rms_forward + rms_backward))
+
+
+_STELLARATOR_SYMMETRY_AUGMENTATION_SWITCHES: tuple[tuple[bool, bool, bool], ...] = (
+    (False, False, False),
+    (False, False, True),
+    (False, True, False),
+    (False, True, True),
+    (True, False, False),
+    (True, False, True),
+    (True, True, False),
+    (True, True, True),
+)
+"""All 8 sign-flip combinations passed to
+:func:`generate_stellarator_symmetric_augmentation` to enumerate the
+stellarator-symmetric augmentations of a surface. Iterating over only
+``surface_2``'s augmentations is sufficient because the augmentation group
+acts on both sides equivalently, so the minimum over 64 pairs equals the
+minimum over the 8 augmentations of one side."""
 
 
 def set_max_mode_numbers(

--- a/src/constellaration/mhd_stable_qi_scoring.py
+++ b/src/constellaration/mhd_stable_qi_scoring.py
@@ -193,6 +193,7 @@ def binned_diversity_score(
     max_per_bin: int = DEFAULT_MAX_PER_BIN,
     n_poloidal_points: int = DEFAULT_N_POLOIDAL_POINTS,
     n_toroidal_points: int = DEFAULT_N_TOROIDAL_POINTS,
+    compare_augmentations: bool = True,
 ) -> float:
     """Binned geometric diversity score across the aspect-ratio range.
 
@@ -219,6 +220,12 @@ def binned_diversity_score(
             compute pairwise distances.
         n_poloidal_points: Poloidal grid resolution for the distance metric.
         n_toroidal_points: Toroidal grid resolution for the distance metric.
+        compare_augmentations: Forwarded to
+            :func:`surface_rz_fourier.compute_rms_normal_displacement_distance`.
+            When True (default) the distance between two boundaries is the
+            minimum across all 8 stellarator-symmetric augmentations of one
+            side, preventing trivial symmetry relabelings from inflating
+            diversity.
 
     Returns:
         Mean diversity score across the ``n_bins`` bins.
@@ -267,6 +274,7 @@ def binned_diversity_score(
             normalized,
             n_poloidal_points=n_poloidal_points,
             n_toroidal_points=n_toroidal_points,
+            compare_augmentations=compare_augmentations,
         )
 
     return float(np.mean(bin_scores))
@@ -276,6 +284,7 @@ def _mean_pairwise_rms_distance(
     boundaries: list[surface_rz_fourier.SurfaceRZFourier],
     n_poloidal_points: int,
     n_toroidal_points: int,
+    compare_augmentations: bool,
 ) -> float:
     """Mean over all unordered pairs of the symmetrized RMS normal distance."""
     distances: list[float] = []
@@ -286,6 +295,7 @@ def _mean_pairwise_rms_distance(
                 b,
                 n_poloidal_points=n_poloidal_points,
                 n_toroidal_points=n_toroidal_points,
+                compare_augmentations=compare_augmentations,
             )
         )
     return float(np.mean(distances))
@@ -351,6 +361,7 @@ def score_boundaries_diversity(
     max_per_bin: int = DEFAULT_MAX_PER_BIN,
     n_poloidal_points: int = DEFAULT_N_POLOIDAL_POINTS,
     n_toroidal_points: int = DEFAULT_N_TOROIDAL_POINTS,
+    compare_augmentations: bool = True,
 ) -> float:
     """Binned geometric diversity score for boundaries near the Pareto front.
 
@@ -376,6 +387,11 @@ def score_boundaries_diversity(
             inclusion. SoW default 0.9.
         ar_min, ar_max, n_bins, max_per_bin, n_poloidal_points,
             n_toroidal_points: Forwarded to :func:`binned_diversity_score`.
+        compare_augmentations: Forwarded to
+            :func:`binned_diversity_score` and ultimately to
+            :func:`surface_rz_fourier.compute_rms_normal_displacement_distance`.
+            When True (default) trivial stellarator-symmetric relabelings
+            of a boundary cannot inflate the diversity score.
 
     Returns:
         Diversity score (a non-negative float).
@@ -425,4 +441,5 @@ def score_boundaries_diversity(
         max_per_bin=max_per_bin,
         n_poloidal_points=n_poloidal_points,
         n_toroidal_points=n_toroidal_points,
+        compare_augmentations=compare_augmentations,
     )

--- a/tests/geometry/surface_rz_fourier_test.py
+++ b/tests/geometry/surface_rz_fourier_test.py
@@ -1349,3 +1349,109 @@ def test_rms_normal_displacement_distance_differs_from_mean_abs_version() -> Non
         a, b, n_poloidal_points=32, n_toroidal_points=8
     )
     assert rms > mean_abs > 0
+
+
+# ---------- compare_augmentations behavior ----------
+
+
+def test_rms_distance_is_invariant_under_stellarator_augmentation() -> None:
+    """A surface and any of its 8 stellarator-symmetric augmentations describe
+    the same physical configuration, so the distance must be ~0 by default."""
+    base = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[0.0, 10.0, 0.0], [0.1, 1.0, 0.2]]),
+        z_sin=np.array([[0.0, 0.0, 0.0], [0.1, 1.0, 0.2]]),
+        n_field_periods=3,
+        is_stellarator_symmetric=True,
+    )
+    import itertools
+
+    for switches in itertools.product([False, True], repeat=3):
+        augmented = surface_rz_fourier.generate_stellarator_symmetric_augmentation(
+            base, augmentation_switches=list(switches)
+        )
+        d = surface_rz_fourier.compute_rms_normal_displacement_distance(
+            base, augmented, n_poloidal_points=16, n_toroidal_points=16
+        )
+        assert d == pytest.approx(
+            0.0, abs=1e-6
+        ), f"distance under switches={switches} was {d}, expected ~0"
+
+
+def test_rms_distance_with_compare_augmentations_off_sees_relabeling() -> None:
+    """With the augmentation search disabled, a toroidal-shift augmentation
+    produces a positive distance even though the 3D shape is unchanged."""
+    base = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[0.0, 10.0, 0.0], [0.1, 1.0, 0.2]]),
+        z_sin=np.array([[0.0, 0.0, 0.0], [0.1, 1.0, 0.2]]),
+        n_field_periods=3,
+        is_stellarator_symmetric=True,
+    )
+    shifted = surface_rz_fourier.generate_stellarator_symmetric_augmentation(
+        base, augmentation_switches=[False, True, False]
+    )
+    d = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        base,
+        shifted,
+        n_poloidal_points=16,
+        n_toroidal_points=16,
+        compare_augmentations=False,
+    )
+    assert d > 0.1
+
+
+def test_rms_distance_with_compare_augmentations_matches_explicit_min() -> None:
+    """The default-on output should equal the minimum across the 8 augmentations
+    of surface_2 computed via the plain (off) variant."""
+    import itertools
+
+    a = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[0.0, 10.0, 0.0], [0.1, 1.0, 0.2]]),
+        z_sin=np.array([[0.0, 0.0, 0.0], [0.1, 1.0, 0.2]]),
+        n_field_periods=3,
+        is_stellarator_symmetric=True,
+    )
+    b = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[0.0, 10.0, 0.0], [0.15, 1.05, 0.18]]),
+        z_sin=np.array([[0.0, 0.0, 0.0], [0.12, 1.05, 0.18]]),
+        n_field_periods=3,
+        is_stellarator_symmetric=True,
+    )
+    explicit_min = min(
+        surface_rz_fourier.compute_rms_normal_displacement_distance(
+            a,
+            surface_rz_fourier.generate_stellarator_symmetric_augmentation(
+                b, augmentation_switches=list(switches)
+            ),
+            n_poloidal_points=16,
+            n_toroidal_points=16,
+            compare_augmentations=False,
+        )
+        for switches in itertools.product([False, True], repeat=3)
+    )
+    auto_min = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        a, b, n_poloidal_points=16, n_toroidal_points=16, compare_augmentations=True
+    )
+    assert auto_min == pytest.approx(explicit_min, rel=1e-12)
+
+
+def test_rms_distance_falls_back_to_pairwise_when_not_stellarator_symmetric() -> None:
+    """For non-stellarator-symmetric surfaces the augmentation scheme does not
+    apply; the function should silently fall back to the plain pairwise
+    distance instead of raising."""
+    a = surface_rz_fourier.SurfaceRZFourier(
+        r_cos=np.array([[0.0, 10.0, 0.0], [0.1, 1.0, 0.2]]),
+        z_sin=np.array([[0.0, 0.0, 0.0], [0.1, 1.0, 0.2]]),
+        r_sin=np.array([[0.0, 0.0, 0.0], [0.0, 0.05, 0.0]]),
+        z_cos=np.array([[0.0, 0.0, 0.0], [0.0, 0.05, 0.0]]),
+        n_field_periods=3,
+        is_stellarator_symmetric=False,
+    )
+    b = a.model_copy()
+    # With the flag on but inputs non-symmetric, expect the same answer as off.
+    d_on = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        a, b, n_poloidal_points=16, n_toroidal_points=16, compare_augmentations=True
+    )
+    d_off = surface_rz_fourier.compute_rms_normal_displacement_distance(
+        a, b, n_poloidal_points=16, n_toroidal_points=16, compare_augmentations=False
+    )
+    assert d_on == pytest.approx(d_off, rel=1e-12)

--- a/tests/mhd_stable_qi_scoring_test.py
+++ b/tests/mhd_stable_qi_scoring_test.py
@@ -508,3 +508,73 @@ def test_score_boundaries_diversity_drops_dominated_levels_via_hiv_filter() -> N
         n_toroidal_points=8,
     )
     assert score == pytest.approx(score_no_dom, rel=1e-9)
+
+
+# ---------- compare_augmentations through scoring API ----------
+
+
+def test_binned_diversity_default_zero_when_partner_is_just_an_augmentation() -> None:
+    """Two boundaries in the same bin where one is a stellarator-symmetric
+    augmentation of the other should score ~0 by default (same physics)."""
+    base = _rotating_ellipse_at_ar(6.3, triangularity=0.1)
+    twin = surface_rz_fourier.generate_stellarator_symmetric_augmentation(
+        base, augmentation_switches=[False, True, False]
+    )
+    score_default = mhd_stable_qi_scoring.binned_diversity_score(
+        boundaries=[base, twin],
+        aspect_ratios=np.array([6.3, 6.3]),
+        lgradB_values=np.array([1.0, 1.0]),
+        n_poloidal_points=16,
+        n_toroidal_points=16,
+    )
+    assert score_default == pytest.approx(0.0, abs=1e-6)
+
+
+def test_binned_diversity_can_be_fooled_when_compare_augmentations_off() -> None:
+    """The opt-out flag exposes the underlying weakness so we can confirm the
+    default really does protect against it."""
+    base = _rotating_ellipse_at_ar(6.3, triangularity=0.1)
+    twin = surface_rz_fourier.generate_stellarator_symmetric_augmentation(
+        base, augmentation_switches=[False, True, False]
+    )
+    score_off = mhd_stable_qi_scoring.binned_diversity_score(
+        boundaries=[base, twin],
+        aspect_ratios=np.array([6.3, 6.3]),
+        lgradB_values=np.array([1.0, 1.0]),
+        n_poloidal_points=16,
+        n_toroidal_points=16,
+        compare_augmentations=False,
+    )
+    # Pre-fix behavior: a fake "different" boundary inflates the bin score.
+    # 1 non-empty bin out of 10 -> overall score ~ d / 10, which is still > 0.
+    assert score_off > 0.01
+
+
+def test_score_boundaries_diversity_flag_propagates() -> None:
+    """Passing compare_augmentations=False through the top-level scorer must
+    reach the underlying distance metric."""
+    base = _rotating_ellipse_at_ar(6.3, triangularity=0.1)
+    twin = surface_rz_fourier.generate_stellarator_symmetric_augmentation(
+        base, augmentation_switches=[False, True, False]
+    )
+    metrics = [
+        _make_metrics(6.3, 3.0),
+        _make_metrics(6.3, 2.9),
+    ]
+    on = mhd_stable_qi_scoring.score_boundaries_diversity(
+        [base, twin],
+        "tight",
+        metrics=metrics,
+        n_poloidal_points=16,
+        n_toroidal_points=16,
+    )
+    off = mhd_stable_qi_scoring.score_boundaries_diversity(
+        [base, twin],
+        "tight",
+        metrics=metrics,
+        n_poloidal_points=16,
+        n_toroidal_points=16,
+        compare_augmentations=False,
+    )
+    assert on == pytest.approx(0.0, abs=1e-6)
+    assert off > 0.01


### PR DESCRIPTION
The symmetrized RMS normal displacement distance previously compared two
boundaries pointwise on a (theta, phi) grid. A contractor could therefore
inflate the binned diversity score by submitting a configuration alongside
its stellarator-symmetric augmentation (z_sin sign flip, toroidal shift by
pi/NFP, or poloidal shift by pi): these describe the same physical 3D
shape but have a large pointwise distance in real space.

compute_rms_normal_displacement_distance now takes
compare_augmentations: bool = True. When True (default) it returns the
minimum RMS distance across all 8 stellarator-symmetric augmentations of
one input -- equivalent to the minimum over all 64 pairs of augmentations
because the augmentation group acts on both sides isometrically. Pass
False to recover the original pointwise behavior (e.g. for non-stellarator
\-symmetric inputs, where the function also falls back automatically).

The flag is forwarded through binned_diversity_score and
score_boundaries_diversity so callers can opt out at the scoring level
too. Existing tests pass unchanged; new tests cover the augmentation
invariance, fall-back for non-symmetric inputs, and that the flag does
propagate through binned_diversity_score and score_boundaries_diversity.